### PR TITLE
Created a Deployment object to capture site and deployment only info

### DIFF
--- a/src/acoupi/types.py
+++ b/src/acoupi/types.py
@@ -1,21 +1,48 @@
 """This module contains the types used by the aucupi"""
+import datetime
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-import datetime
 from typing import List, Optional
 
 
 @dataclass
+class Deployment:
+    """A Deployment captures information about the device deployment.
+
+    This includes the latitude, longitude, and deployment start.
+    """
+
+    latitude: Optional[float]
+    """The latitude of the site where the device is deployed."""
+
+    longitude: Optional[float]
+    """The longitude of the site where the device is deployed."""
+
+    start: datetime.datetime
+    """The datetime when the device was deployed."""
+
+    device_id: str
+    """The ID of the device."""
+
+
+@dataclass
 class Recording:
-    """A Recording is a single audio file recorded from the microphone"""
+    """A Recording is a single audio file recorded from the microphone."""
 
     path: str
+    """The path to the audio file in the local filesystem"""
+
     datetime: datetime.datetime
+    """The datetime when the recording was made"""
+
     duration: float
+    """The duration of the recording in seconds"""
+
     samplerate: int
-    device_id: Optional[str]
-    lat: Optional[float]
-    lon: Optional[float]
+    """The samplerate of the recording in Hz"""
+
+    deployment: Optional[Deployment] = None
+    """The deployment information for the recording"""
 
 
 @dataclass
@@ -23,7 +50,10 @@ class Detection:
     """A Detection is a single prediction from a model."""
 
     species_name: str
+    """The name of the species predicted by the model"""
+
     probability: float
+    """The probability of the prediction"""
 
 
 class ScheduleManager(ABC):
@@ -108,6 +138,11 @@ class Store(ABC):
     1. If the detection should be stored
     2. How the detection should be stored
     """
+
+    @abstractmethod
+    def store_recording(self, recording: Recording) -> None:
+        """Store the recording locally"""
+        ...
 
     @abstractmethod
     def store_detections(


### PR DESCRIPTION
Hi @audevuilli!

Since we discussed the other day about having information about the deployment I thought it would be good to include a `Deployment` class in the blueprint module `acoupi.types`. This implies some changes on the `Recording` class, as the latitude, longitude and device_id info can now be moved to the deployment class.  I think this is a better way of structuring data but let me know what you think.

Accepting this change might break some of your classes, but I hope the changes necessary should be easy.

Now that we are talking about `Deployment`s we could also think about what is going to be the user experience when deploying the acoupi:

1. How will users deploy the acoupi?
2. When will they fill in the latitude, longitude info?
3. How can they declare a new deployment?