### PR TITLE
Fix/Improve recording saving logic

### DIFF
--- a/src/acoupi/components/saving_managers.py
+++ b/src/acoupi/components/saving_managers.py
@@ -98,7 +98,7 @@ class SaveRecordingManager(types.RecordingSavingManager):
     def get_saving_recording_path(
         self,
         model_outputs: Optional[List[data.ModelOutput]],
-    ) -> Path:
+    ) -> Optional[Path]:
         """Determine where the recording should be saved.
 
         Parameters
@@ -140,15 +140,13 @@ class SaveRecordingManager(types.RecordingSavingManager):
             ):
                 return self.dirpath_false
 
-        return (
-            self.dirpath
-        )  # Default path if any of the above conditions are not met.
+        return None
 
     def save_recording(
         self,
         recording: data.Recording,
         model_outputs: Optional[List[data.ModelOutput]] = None,
-    ) -> Path:
+    ) -> Optional[Path]:
         """Save a recording to a file.
 
         Examples
@@ -174,10 +172,11 @@ class SaveRecordingManager(types.RecordingSavingManager):
             raise ValueError("Recording has no path")
 
         sdir = self.get_saving_recording_path(model_outputs)
-        srec_filename = recording.created_on.strftime(self.timeformat)
 
         if sdir is None:
-            raise ValueError("No directory to save recording.")
+            return None
+
+        srec_filename = recording.created_on.strftime(self.timeformat)
 
         # Move recording to the path it should be saved
         new_path = sdir / f"{srec_filename}.wav"

--- a/src/acoupi/components/types.py
+++ b/src/acoupi/components/types.py
@@ -272,7 +272,7 @@ class RecordingSavingManager(ABC):
         self,
         recording: data.Recording,
         model_outputs: Optional[List[data.ModelOutput]] = None,
-    ) -> Path:
+    ) -> Optional[Path]:
         """Save the recording.
 
         Parameters
@@ -285,8 +285,9 @@ class RecordingSavingManager(ABC):
 
         Returns
         -------
-        Path
-            The path to the saved recording.
+        Optional[Path]
+            The path to the saved recording. Returns None if this
+            manager is not responsible for saving the recording.
         """
 
 

--- a/src/acoupi/tasks/management.py
+++ b/src/acoupi/tasks/management.py
@@ -110,18 +110,19 @@ def generate_file_management_task(
                 continue
 
             # Which files should be saved?
-            for file_filter in file_filters or []:
-                if not file_filter.should_save_recording(
+            if file_filters and not any(
+                file_filter.should_save_recording(
                     recording,
                     model_outputs=model_outputs,
-                ):
-                    logger.info(
-                        "Recording %s does not pass filter: %s",
-                        recording,
-                        file_filter,
-                    )
-                    delete_recording(recording)
-                    break
+                )
+                for file_filter in file_filters
+            ):
+                logger.info(
+                    "Recording %s does not pass filters",
+                    recording,
+                )
+                delete_recording(recording)
+                continue
 
             # Has the file already been deleted?
             if not recording.path.exists():

--- a/src/acoupi/tasks/management.py
+++ b/src/acoupi/tasks/management.py
@@ -153,5 +153,6 @@ def generate_file_management_task(
                     "No file manager was able to save recording %s",
                     recording,
                 )
+                delete_recording(recording)
 
     return file_management_task

--- a/tests/test_components/test_saving_managers.py
+++ b/tests/test_components/test_saving_managers.py
@@ -14,7 +14,8 @@ from acoupi.components import saving_managers
 def create_test_recording():
     """Fixture for creating random recording.
 
-    Will create a recording with a path, duration, samplerate, deployment and datetime.
+    Will create a recording with a path, duration, samplerate, deployment and
+    datetime.
     """
     deployment = data.Deployment(
         name="test_deployment",
@@ -223,7 +224,7 @@ def test_save_recording_with_unconfident_detections(
     assert new_path.parent == tmp_dirpath_false
 
 
-def test_recording_is_saved_in_default_dir_if_not_true_or_false_class(
+def test_none_is_returned_if_not_true_or_false_class(
     tmp_path: Path,
     create_test_recording,
     create_test_detection,
@@ -275,8 +276,7 @@ def test_recording_is_saved_in_default_dir_if_not_true_or_false_class(
 
     # Assert saves in the root folder and not in any of the true or false
     # subdirectories
-    assert new_path is not None
-    assert new_path.parent == tmp_audio_dirpath
+    assert new_path is None
 
 
 def test_date_file_manager_save_recording(


### PR DESCRIPTION
This PR refines the file management task's recording saving logic to be more robust and flexible.

Key changes:

**Saving Logic:** Recordings are now saved if any file saving filter returns True, ensuring that recordings are preserved when at least one filter indicates they should be. This aligns with the conveyed purpose of the _should_save_recording_ method in the filters.
**File Manager Responsibility:** The file manager abstract class now allows returning None to signal that a specific manager is not responsible for saving a given recording. This enables the file management task to iterate through all managers until a suitable saving location is found. If no manager claims responsibility, the recording is deleted.
These changes improve the reliability and clarity of the file management process.  Tests have been updated to reflect the new behavior.

Tests have been updated to reflect the new behavior.