### PR TITLE
Default tomulti-user.targetin service installation

### DIFF
--- a/src/acoupi/templates/acoupi.service.jinja2
+++ b/src/acoupi/templates/acoupi.service.jinja2
@@ -13,4 +13,4 @@ Restart=always
 RestartSec=3
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target

--- a/src/acoupi/templates/acoupi_beat.service.jinja2
+++ b/src/acoupi/templates/acoupi_beat.service.jinja2
@@ -11,4 +11,4 @@ Restart=always
 RestartSec=3
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
This PR updates the acoupi service unit description, by modifying the installation to target default.target by default. This ensures the service is always installed even if the system is not specifically targeting a multi-user environment.