### PR TITLE
Feat/Add task management commands

### DIFF
--- a/docs/reference/system.md
+++ b/docs/reference/system.md
@@ -24,4 +24,6 @@
 
 ::: acoupi.system.state
 
+::: acoupi.system.tasks
+
 ::: acoupi.system.templates

--- a/src/acoupi/cli/__init__.py
+++ b/src/acoupi/cli/__init__.py
@@ -3,11 +3,13 @@
 from acoupi.cli.base import acoupi
 from acoupi.cli.config import config
 from acoupi.cli.deployment import deployment
+from acoupi.cli.tasks import task
 
 __all__ = [
     "acoupi",
     "config",
     "deployment",
+    "task",
 ]
 
 

--- a/src/acoupi/cli/tasks.py
+++ b/src/acoupi/cli/tasks.py
@@ -117,4 +117,8 @@ def profile(
 
     if not quiet:
         click.echo(f"Profiling task {click.style(task_name, fg='green')}")
-    system.profile_task(program, task_name, output=output)
+
+    stats = system.profile_task(program, task_name)
+
+    if output:
+        stats.dump_stats(output)

--- a/src/acoupi/cli/tasks.py
+++ b/src/acoupi/cli/tasks.py
@@ -1,0 +1,95 @@
+import logging
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from acoupi import system
+from acoupi.cli.base import acoupi
+
+__all__ = [
+    "task",
+]
+
+
+@acoupi.group()
+@click.pass_context
+def task(ctx):
+    """Manage acoupi tasks."""
+    settings = ctx.obj["settings"]
+    if not system.is_configured(settings):
+        click.echo("Acoupi is not setup. Run `acoupi setup` first.")
+        return
+
+
+@task.command()
+@click.pass_context
+def list(ctx):
+    program = system.load_program(ctx.obj["settings"])
+    task_list = system.get_task_list(program)
+
+    click.echo(
+        "Program "
+        + click.style(type(program).__name__, fg="green", bold=True)
+        + " tasks:\n"
+    )
+
+    for task in task_list:
+        click.secho(f"  • {task}", bold=True)
+
+
+@task.command()
+@click.argument("task_name", type=str)
+@click.pass_context
+def run(ctx, task_name: str):
+    program = system.load_program(ctx.obj["settings"])
+    task_list = system.get_task_list(program)
+
+    if task_name not in task_list:
+        raise click.UsageError(
+            click.style("Task ", fg="red")
+            + click.style(task_name, fg="red", bold=True)
+            + click.style(" not found.", fg="red")
+        )
+
+    click.echo(f"Running task {click.style(task_name, fg='green')}")
+    system.run_task(program, task_name)
+
+
+@task.command()
+@click.argument("task_name", type=str)
+@click.option("--output", type=Path)
+@click.option(
+    "--quiet",
+    type=bool,
+    default=False,
+)
+@click.option(
+    "--log-level",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
+    default="WARNING",
+)
+@click.pass_context
+def profile(
+    ctx,
+    task_name: str,
+    output: Optional[Path],
+    quiet: bool,
+    log_level: str,
+):
+    program = system.load_program(ctx.obj["settings"])
+    task_list = system.get_task_list(program)
+
+    if not quiet:
+        logging.basicConfig(level=log_level)
+
+    if task_name not in task_list:
+        raise click.UsageError(
+            click.style("Task ", fg="red")
+            + click.style(task_name, fg="red", bold=True)
+            + click.style(" not found.", fg="red")
+        )
+
+    if not quiet:
+        click.echo(f"Profiling task {click.style(task_name, fg='green')}")
+    system.profile_task(program, task_name, output=output)

--- a/src/acoupi/cli/tasks.py
+++ b/src/acoupi/cli/tasks.py
@@ -15,7 +15,11 @@ __all__ = [
 @acoupi.group()
 @click.pass_context
 def task(ctx):
-    """Manage acoupi tasks."""
+    """Manage acoupi tasks.
+
+    Provides commands to list, run, and profile tasks within
+    your configured acoupi program.
+    """
     settings = ctx.obj["settings"]
     if not system.is_configured(settings):
         click.echo("Acoupi is not setup. Run `acoupi setup` first.")
@@ -25,6 +29,7 @@ def task(ctx):
 @task.command()
 @click.pass_context
 def list(ctx):
+    """List all available tasks in the current acoupi program."""
     program = system.load_program(ctx.obj["settings"])
     task_list = system.get_task_list(program)
 
@@ -42,6 +47,13 @@ def list(ctx):
 @click.argument("task_name", type=str)
 @click.pass_context
 def run(ctx, task_name: str):
+    """Run a specified task.
+
+    Parameters
+    ----------
+    task_name : str
+        The name of the task to run.
+    """
     program = system.load_program(ctx.obj["settings"])
     task_list = system.get_task_list(program)
 
@@ -58,16 +70,22 @@ def run(ctx, task_name: str):
 
 @task.command()
 @click.argument("task_name", type=str)
-@click.option("--output", type=Path)
+@click.option(
+    "--output",
+    type=Path,
+    help="Path to save profiling output.",
+)
 @click.option(
     "--quiet",
     type=bool,
     default=False,
+    help="Suppress printing profiling output to the console.",
 )
 @click.option(
     "--log-level",
     type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
     default="WARNING",
+    help="Set the logging level.",
 )
 @click.pass_context
 def profile(
@@ -77,6 +95,13 @@ def profile(
     quiet: bool,
     log_level: str,
 ):
+    """Profile a specified task.
+
+    Parameters
+    ----------
+    task_name : str
+        The name of the task to profile.
+    """
     program = system.load_program(ctx.obj["settings"])
     task_list = system.get_task_list(program)
 

--- a/src/acoupi/programs/core/base.py
+++ b/src/acoupi/programs/core/base.py
@@ -142,10 +142,14 @@ class AcoupiProgram(ABC, Generic[ProgramConfig]):
         callbacks: Optional[List[Callable[[Optional[B]], None]]] = None,
         schedule: Union[int, datetime.timedelta, crontab, None] = None,
         queue: Optional[str] = None,
+        name: Optional[str] = None,
     ):
         """Add a task to the program."""
         if not callbacks:
             callbacks = []
+
+        if name is None:
+            name = function.__name__
 
         callback_tasks = []
         for callback in callbacks:
@@ -160,15 +164,15 @@ class AcoupiProgram(ABC, Generic[ProgramConfig]):
             callback_tasks.append(callback_task)
 
         # Add the task to the list of tasks
-        task = self._add_task(function, callback_tasks)
+        task = self._add_task(function, callback_tasks, name=name)
 
         if queue:
             # add the task to the queue
-            self.add_task_to_queue(function.__name__, queue)
+            self.add_task_to_queue(name, queue)
 
         if schedule:
             # configure the app to schedule the task
-            self.app.add_periodic_task(schedule, task, name=task.__name__)
+            self.app.add_periodic_task(schedule, task, name=name)
 
     def add_task_to_queue(self, task_name: str, queue: str):
         """Add a task to a queue."""
@@ -188,11 +192,13 @@ class AcoupiProgram(ABC, Generic[ProgramConfig]):
         self,
         function: Callable[[], Optional[B]],
         callback_tasks: Optional[List[Task]] = None,
+        name: Optional[str] = None,
     ) -> Task:
         # TODO: Check Celery docs for best callback practices
 
         # Use the function name as the task name
-        name = function.__name__
+        if name is None:
+            name = function.__name__
 
         logger = self.logger.getChild(name)
 

--- a/src/acoupi/programs/core/base.py
+++ b/src/acoupi/programs/core/base.py
@@ -213,17 +213,18 @@ class AcoupiProgram(ABC, Generic[ProgramConfig]):
 
             if result is None:
                 # the task did not return anything do not run the callbacks
-                return
+                return result
 
             if not callback_tasks:
                 # there are no callbacks to run
-                return
+                return result
 
             logger.debug("Queueing callbacks with result: %s", result)
 
             # run the callbacks as a group
             callback_group = group(task.s(result) for task in callback_tasks)
             callback_group.apply_async()
+            return result
 
         # register the task with the app
         task = self.app.task(decorated_function, name=name)

--- a/src/acoupi/system/__init__.py
+++ b/src/acoupi/system/__init__.py
@@ -42,6 +42,7 @@ from acoupi.system.services import (
     stop_services,
 )
 from acoupi.system.state import AcoupiStatus, get_status, is_configured
+from acoupi.system.tasks import get_task_list, profile_task, run_task
 
 __all__ = [
     "AcoupiStatus",
@@ -55,6 +56,7 @@ __all__ = [
     "get_config_field",
     "get_current_deployment",
     "get_status",
+    "get_task_list",
     "get_temp_file_id",
     "get_temp_files",
     "is_configured",
@@ -64,7 +66,9 @@ __all__ = [
     "load_program_class",
     "move_recording",
     "parse_config_from_args",
+    "profile_task",
     "run_celery_command",
+    "run_task",
     "services_are_installed",
     "set_config_field",
     "setup_program",

--- a/src/acoupi/system/tasks.py
+++ b/src/acoupi/system/tasks.py
@@ -47,7 +47,7 @@ def get_task_list(
 def run_task(
     program: AcoupiProgram,
     task_name: str,
-) -> None:
+):
     """Run a task from the current program.
 
     Parameters
@@ -73,7 +73,7 @@ def run_task(
     if task_name not in app.tasks:
         raise ValueError(f"Task {task_name} not found.")
     task = app.tasks[task_name]
-    task()
+    return task.apply().get()
 
 
 def profile_task(

--- a/src/acoupi/system/tasks.py
+++ b/src/acoupi/system/tasks.py
@@ -1,3 +1,9 @@
+"""Acoupi system tasks module.
+
+This module provides a set of functions to help manage and interact with
+the tasks of the currently configured acoupi program.
+"""
+
 import cProfile
 from pathlib import Path
 from typing import List, Optional
@@ -9,6 +15,25 @@ def get_task_list(
     program: AcoupiProgram,
     include_celery_tasks: bool = False,
 ) -> List[str]:
+    """Return a list of all the tasks registered in the current program.
+
+    Parameters
+    ----------
+    program : AcoupiProgram
+        The AcoupiProgram instance to get the tasks from.
+    include_celery_tasks : bool, optional
+        Whether to include celery tasks in the list. Defaults to False.
+
+    Returns
+    -------
+    List[str]
+        List of the names of available tasks.
+
+    Notes
+    -----
+    Celery registers a number of tasks by default, which can be excluded
+    from the list by setting `include_celery_tasks` to `False`.
+    """
     app = program.app
 
     tasks = [task_name for task_name in app.tasks.keys()]
@@ -23,6 +48,27 @@ def run_task(
     program: AcoupiProgram,
     task_name: str,
 ) -> None:
+    """Run a task from the current program.
+
+    Parameters
+    ----------
+    program : AcoupiProgram
+        The AcoupiProgram instance to run the task from.
+    task_name : str
+        The name of the task to run.
+
+    Raises
+    ------
+    ValueError
+        If the specified task is not found.
+
+    Notes
+    -----
+    This function runs the task in the current Python process and does not
+    send the task to the Celery workers. This can be helpful for testing a
+    task without setting up Celery workers. To run the task through Celery
+    workers, use the `acoupi celery call <task_name>` command.
+    """
     app = program.app
     if task_name not in app.tasks:
         raise ValueError(f"Task {task_name} not found.")
@@ -35,15 +81,38 @@ def profile_task(
     task_name: str,
     output: Optional[Path] = None,
 ) -> None:
+    """Profile a task from the current program.
+
+    Parameters
+    ----------
+    program : AcoupiProgram
+        The AcoupiProgram instance to profile the task from.
+    task_name : str
+        The name of the task to profile.
+    output : Optional[Path], optional
+        The path to save the profiling output. If not provided,
+        the output will be printed to the console. Defaults to None.
+
+    Raises
+    ------
+    ValueError
+        If the specified task is not found.
+
+    Notes
+    -----
+    This function uses cProfile to profile the task. The output can
+    be saved to a file by providing the `output` parameter. The task
+    is run in the current Python process and does not send the task to
+    the Celery workers, so the profiling will only show the performance
+    of the task without the overhead of the Celery workers.
+    """
     app = program.app
     if task_name not in app.tasks:
         raise ValueError(f"Task {task_name} not found.")
     task = app.tasks[task_name]
 
     with cProfile.Profile() as profiler:
-        profiler.enable()
         task()
-        profiler.disable()
 
         if output is not None:
             profiler.dump_stats(str(output))

--- a/src/acoupi/system/tasks.py
+++ b/src/acoupi/system/tasks.py
@@ -1,0 +1,51 @@
+import cProfile
+from pathlib import Path
+from typing import List, Optional
+
+from acoupi.programs import AcoupiProgram
+
+
+def get_task_list(
+    program: AcoupiProgram,
+    include_celery_tasks: bool = False,
+) -> List[str]:
+    app = program.app
+
+    tasks = [task_name for task_name in app.tasks.keys()]
+
+    if not include_celery_tasks:
+        tasks = [task for task in tasks if "celery" not in task]
+
+    return tasks
+
+
+def run_task(
+    program: AcoupiProgram,
+    task_name: str,
+) -> None:
+    app = program.app
+    if task_name not in app.tasks:
+        raise ValueError(f"Task {task_name} not found.")
+    task = app.tasks[task_name]
+    task()
+
+
+def profile_task(
+    program: AcoupiProgram,
+    task_name: str,
+    output: Optional[Path] = None,
+) -> None:
+    app = program.app
+    if task_name not in app.tasks:
+        raise ValueError(f"Task {task_name} not found.")
+    task = app.tasks[task_name]
+
+    with cProfile.Profile() as profiler:
+        profiler.enable()
+        task()
+        profiler.disable()
+
+        if output is not None:
+            profiler.dump_stats(str(output))
+        else:
+            profiler.print_stats()

--- a/src/acoupi/system/tasks.py
+++ b/src/acoupi/system/tasks.py
@@ -6,6 +6,7 @@ the tasks of the currently configured acoupi program.
 
 import cProfile
 from pathlib import Path
+from pstats import Stats
 from typing import List, Optional
 
 from acoupi.programs import AcoupiProgram
@@ -79,8 +80,7 @@ def run_task(
 def profile_task(
     program: AcoupiProgram,
     task_name: str,
-    output: Optional[Path] = None,
-) -> None:
+) -> Stats:
     """Profile a task from the current program.
 
     Parameters
@@ -114,7 +114,5 @@ def profile_task(
     with cProfile.Profile() as profiler:
         task()
 
-        if output is not None:
-            profiler.dump_stats(str(output))
-        else:
-            profiler.print_stats()
+        profiler.create_stats()
+        return Stats(profiler)

--- a/src/acoupi/system/tasks.py
+++ b/src/acoupi/system/tasks.py
@@ -5,9 +5,8 @@ the tasks of the currently configured acoupi program.
 """
 
 import cProfile
-from pathlib import Path
 from pstats import Stats
-from typing import List, Optional
+from typing import List
 
 from acoupi.programs import AcoupiProgram
 

--- a/tests/test_cli/test_tasks.py
+++ b/tests/test_cli/test_tasks.py
@@ -1,0 +1,42 @@
+"""Test suite for the CLI task commands."""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from acoupi import system
+from acoupi.cli import acoupi
+
+
+@pytest.fixture(autouse=True)
+def setup_program(settings: system.Settings):
+    system.setup_program(settings, "acoupi.programs.test", prompt=False)
+
+
+def test_can_get_the_full_list_of_test_program_tasks(
+    settings: system.Settings,
+):
+    runner = CliRunner()
+    result = runner.invoke(
+        acoupi,
+        ["task", "list"],
+        obj={"settings": settings},
+    )
+    assert result.exit_code == 0
+    assert "test_task" in result.output
+
+
+def test_can_save_the_task_profile_to_a_file(
+    settings: system.Settings,
+    tmp_path: Path,
+):
+    runner = CliRunner()
+    profile_path = tmp_path / "profile.prof"
+    result = runner.invoke(
+        acoupi,
+        ["task", "profile", "test_task", "--output", str(profile_path)],
+        obj={"settings": settings},
+    )
+    assert result.exit_code == 0
+    assert profile_path.exists()

--- a/tests/test_cli/test_tasks.py
+++ b/tests/test_cli/test_tasks.py
@@ -9,12 +9,13 @@ from acoupi import system
 from acoupi.cli import acoupi
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def setup_program(settings: system.Settings):
     system.setup_program(settings, "acoupi.programs.test", prompt=False)
 
 
 def test_can_get_the_full_list_of_test_program_tasks(
+    setup_program,
     settings: system.Settings,
 ):
     runner = CliRunner()
@@ -28,6 +29,7 @@ def test_can_get_the_full_list_of_test_program_tasks(
 
 
 def test_can_save_the_task_profile_to_a_file(
+    setup_program,
     settings: system.Settings,
     tmp_path: Path,
 ):

--- a/tests/test_system/test_tasks.py
+++ b/tests/test_system/test_tasks.py
@@ -1,0 +1,56 @@
+"""Task suite for acoupi.system.tasks module."""
+
+from pstats import Stats
+from unittest import mock
+
+import pytest
+from celery import Celery
+from pydantic import BaseModel
+
+from acoupi import system
+from acoupi.programs import AcoupiProgram
+
+
+class Config(BaseModel):
+    a: int = 1
+
+
+@pytest.fixture
+def setup_program(settings: system.Settings):
+    system.setup_program(settings, "acoupi.programs.test", prompt=False)
+
+
+def test_list_of_tasks_does_not_show_default_celery_tasks(
+    setup_program,
+    settings: system.Settings,
+):
+    program = system.load_program(settings)
+    tasks = system.get_task_list(program)
+    assert not any("celery" in task for task in tasks)
+
+
+@pytest.mark.usefixtures("celery_app")
+def test_can_run_a_task(celery_app: Celery):
+    task = mock.Mock()
+
+    class Program(AcoupiProgram):
+        config_schema = Config
+
+        def setup(self, config):
+            self.add_task(task, name="test_task")
+
+    program = Program(Config(), celery_app)
+
+    system.run_task(program, "test_task")
+
+    assert task.called
+
+
+def test_profile_returns_the_full_profile(
+    setup_program,
+    settings: system.Settings,
+):
+    program = system.load_program(settings)
+    tasks = system.get_task_list(program)
+    profile = system.profile_task(program, tasks[0])
+    assert isinstance(profile, Stats)

--- a/tests/test_system/test_tasks.py
+++ b/tests/test_system/test_tasks.py
@@ -29,8 +29,7 @@ def test_list_of_tasks_does_not_show_default_celery_tasks(
     assert not any("celery" in task for task in tasks)
 
 
-@pytest.mark.usefixtures("celery_app")
-def test_can_run_a_task(celery_app: Celery):
+def test_can_run_a_task():
     task = mock.Mock()
 
     class Program(AcoupiProgram):
@@ -39,11 +38,11 @@ def test_can_run_a_task(celery_app: Celery):
         def setup(self, config):
             self.add_task(task, name="test_task")
 
-    program = Program(Config(), celery_app)
+    program = Program(Config(), Celery())
 
     system.run_task(program, "test_task")
 
-    assert task.called
+    task.assert_called()
 
 
 def test_profile_returns_the_full_profile(

--- a/tests/test_system/test_tasks.py
+++ b/tests/test_system/test_tasks.py
@@ -28,29 +28,6 @@ def test_list_of_tasks_does_not_show_default_celery_tasks(
     assert not any("celery" in task for task in tasks)
 
 
-@pytest.mark.usefixtures("celery_app")
-def test_can_run_a_task(celery_app: Celery):
-    class DummyProgram(AcoupiProgram):
-        config_schema = Config
-
-        def setup(self, config):
-            def dummy_task():
-                # NOTE: Strangely enough this test only works if the
-                # print statement is here. If the test is run
-                # individually without the print statement it does pass,
-                # but when run with the rest of the tests it fails.
-                print("Huh?")
-                return "done"
-
-            self.add_task(dummy_task, name="test_task")
-
-    program = DummyProgram(Config(), celery_app)
-
-    output = system.run_task(program, "test_task")
-
-    assert output == "done"
-
-
 def test_profile_returns_the_full_profile(
     setup_program,
     settings: system.Settings,


### PR DESCRIPTION
This PR introduces a new command group to the CLI for managing and interacting with program tasks.  The following subcommands are now available:

 - `acoupi task list`: Lists all registered tasks within the currently configured program. This is useful for verifying task registration and debugging.
- `acoupi task run`: Executes a specific task directly, bypassing the Celery worker. This enables convenient task testing and debugging without requiring the full Celery infrastructure.
- `acoupi task profile`: Runs a task with a profiler and outputs performance data to the console or a file. This aids in analyzing task performance and identifying potential bottlenecks.

To support these CLI commands, a new module (`acoupi.system.tasks`) has been added. This module provides functions for accessing task information and executing tasks, allowing for reuse in other scripts or processes.

Tests have been added to verify the functionality of the new commands and module.