### PR TITLE
Feat/Add commands for manual worker management

### DIFF
--- a/src/acoupi/cli/__init__.py
+++ b/src/acoupi/cli/__init__.py
@@ -3,11 +3,13 @@
 from acoupi.cli.base import acoupi
 from acoupi.cli.config import config
 from acoupi.cli.deployment import deployment
+from acoupi.cli.workers import workers
 
 __all__ = [
     "acoupi",
     "config",
     "deployment",
+    "workers",
 ]
 
 

--- a/src/acoupi/cli/workers.py
+++ b/src/acoupi/cli/workers.py
@@ -1,0 +1,43 @@
+import click
+
+from acoupi import system
+from acoupi.cli.base import acoupi
+
+__all__ = [
+    "workers",
+]
+
+
+@acoupi.group()
+@click.pass_context
+def workers(ctx):
+    """Manage acoupi tasks."""
+    settings = ctx.obj["settings"]
+    if not system.is_configured(settings):
+        raise click.UsageError(
+            "Acoupi is not setup. Run `acoupi setup` first."
+        )
+
+
+@workers.command()
+@click.pass_context
+def start(ctx):
+    """Run a celery command."""
+    settings: system.Settings = ctx.obj["settings"]
+    system.start_workers(settings)
+
+
+@workers.command()
+@click.pass_context
+def restart(ctx):
+    """Run a celery command."""
+    settings: system.Settings = ctx.obj["settings"]
+    system.restart_workers(settings)
+
+
+@workers.command()
+@click.pass_context
+def stop(ctx):
+    """Run a celery command."""
+    settings: system.Settings = ctx.obj["settings"]
+    system.stop_workers(settings)

--- a/src/acoupi/cli/workers.py
+++ b/src/acoupi/cli/workers.py
@@ -1,3 +1,23 @@
+"""Acoupi Workers CLI Commands.
+
+This module provides command-line interface (CLI) commands for manually
+managing Acoupi workers.
+
+While _acoupi_ primarily relies on systemd for robust worker management in
+deployments (initiated via `acoupi deployment start`), these commands offer
+direct control over worker processes for testing and debugging purposes.
+
+With these commands, you can:
+
+- **Start Workers:** Manually launch worker processes to handle task execution.
+- **Restart Workers:**  Restart workers to apply configuration
+    changes or troubleshoot issues.
+- **Stop Workers:**  Safely shut down worker processes.
+
+This manual control can be valuable in development and testing scenarios where
+interacting directly with the workers is necessary.
+"""
+
 import click
 
 from acoupi import system
@@ -11,7 +31,11 @@ __all__ = [
 @acoupi.group()
 @click.pass_context
 def workers(ctx):
-    """Manage acoupi tasks."""
+    """Manage acoupi workers.
+
+    Provides subcommands to manually control the Celery workers responsible for
+    executing program tasks.
+    """
     settings = ctx.obj["settings"]
     if not system.is_configured(settings):
         raise click.UsageError(
@@ -22,7 +46,11 @@ def workers(ctx):
 @workers.command()
 @click.pass_context
 def start(ctx):
-    """Run a celery command."""
+    """Start the Celery workers.
+
+    Manually starts the worker processes that handle the execution of program
+    tasks.
+    """
     settings: system.Settings = ctx.obj["settings"]
     system.start_workers(settings)
 
@@ -30,7 +58,11 @@ def start(ctx):
 @workers.command()
 @click.pass_context
 def restart(ctx):
-    """Run a celery command."""
+    """Restart the Celery workers.
+
+    Restarts the worker processes, which can be useful for applying
+    configuration changes or resolving issues.
+    """
     settings: system.Settings = ctx.obj["settings"]
     system.restart_workers(settings)
 
@@ -38,6 +70,10 @@ def restart(ctx):
 @workers.command()
 @click.pass_context
 def stop(ctx):
-    """Run a celery command."""
+    """Stop the Celery workers.
+
+    Manually stops the worker processes, gracefully shutting down the task
+    execution environment.
+    """
     settings: system.Settings = ctx.obj["settings"]
     system.stop_workers(settings)

--- a/src/acoupi/system/__init__.py
+++ b/src/acoupi/system/__init__.py
@@ -5,7 +5,13 @@ such as loading programs and getting celery apps from programs.
 """
 
 from acoupi.system.apps import get_celery_app
-from acoupi.system.celery import get_celery_status, run_celery_command
+from acoupi.system.celery import (
+    get_celery_status,
+    restart_workers,
+    run_celery_command,
+    start_workers,
+    stop_workers,
+)
 from acoupi.system.config import (
     dump_config,
     get_config_field,
@@ -64,6 +70,7 @@ __all__ = [
     "load_program_class",
     "move_recording",
     "parse_config_from_args",
+    "restart_workers",
     "run_celery_command",
     "services_are_installed",
     "set_config_field",
@@ -71,9 +78,11 @@ __all__ = [
     "start_deployment",
     "start_program",
     "start_services",
+    "start_workers",
     "status_services",
     "stop_program",
     "stop_services",
+    "stop_workers",
     "write_config",
     "write_program_file",
     "get_celery_status",

--- a/src/acoupi/system/celery.py
+++ b/src/acoupi/system/celery.py
@@ -123,6 +123,22 @@ def start_workers(
         Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
     ] = None,
 ):
+    """Start the Celery workers.
+
+    Parameters
+    ----------
+    settings : Settings
+        The current acoupi settings.
+    pool : Literal, optional
+        The pool type for the workers, by default "threads".
+    log_level : Optional[Literal], optional
+        The log level for the workers, by default None.
+
+    Returns
+    -------
+    CompletedProcess
+        The result of the subprocess.run function.
+    """
     cwd = settings.home.absolute()
     app_path = settings.program_file.relative_to(settings.home)
     app = ".".join(app_path.parts).replace(".py", "")
@@ -150,6 +166,20 @@ def restart_workers(
         Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
     ] = None,
 ):
+    """Restart the Celery workers.
+
+    Parameters
+    ----------
+    settings : Settings
+        The current acoupi settings.
+    log_level : Optional[Literal], optional
+        The log level for the workers, by default None.
+
+    Returns
+    -------
+    CompletedProcess
+        The result of the subprocess.run function.
+    """
     cwd = settings.home.absolute()
     app_path = settings.program_file.relative_to(settings.home)
     app = ".".join(app_path.parts).replace(".py", "")
@@ -176,6 +206,20 @@ def stop_workers(
         Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
     ] = None,
 ):
+    """Stop the Celery workers.
+
+    Parameters
+    ----------
+    settings : Settings
+        The current acoupi settings.
+    log_level : Optional[Literal], optional
+        The log level for the workers, by default None.
+
+    Returns
+    -------
+    CompletedProcess
+        The result of the subprocess.run function.
+    """
     cwd = settings.home.absolute()
     app_path = settings.program_file.relative_to(settings.home)
     app = ".".join(app_path.parts).replace(".py", "")


### PR DESCRIPTION
This PR introduces a new CLI command group (`acoupi workers`) to provide manual control over Acoupi worker processes.

The following subcommands are now available:

* `acoupi workers start`: Manually starts the Celery workers responsible for executing tasks.
* `acoupi workers restart`: Restarts the Celery workers, which can be useful for applying configuration changes or troubleshooting issues.
* `acoupi workers stop`: Gracefully stops the Celery workers.

While Acoupi typically relies on systemd for robust worker management within deployments (initiated with `acoupi deployment start`), these commands offer greater control for testing, debugging, and specialized use cases.

To support this functionality, the `acoupi.system.celery` module has been expanded with functions for managing worker processes. These functions can be reused in other system scripts or processes as needed.