### PR TITLE
Fix/GH-63: Prevent Queue Backlogs on Startup and Handle Long-Running Tasks

### DIFF
--- a/src/acoupi/cli/deployment.py
+++ b/src/acoupi/cli/deployment.py
@@ -54,6 +54,7 @@ def start(ctx, name, latitude, longitude, check):
         ctx.invoke(check_command)
 
     click.secho("Starting acoupi...", fg="green")
+    system.purge_queues(settings)
     system.start_program(settings, name, latitude, longitude)
     click.secho("Acoupi started.", fg="green")
 

--- a/src/acoupi/cli/workers.py
+++ b/src/acoupi/cli/workers.py
@@ -77,3 +77,11 @@ def stop(ctx):
     """
     settings: system.Settings = ctx.obj["settings"]
     system.stop_workers(settings)
+
+
+@workers.command()
+@click.pass_context
+def purge(ctx):
+    """Purge all pending tasks from the Celery queue."""
+    settings: system.Settings = ctx.obj["settings"]
+    system.purge_queues(settings)

--- a/src/acoupi/system/__init__.py
+++ b/src/acoupi/system/__init__.py
@@ -7,6 +7,7 @@ such as loading programs and getting celery apps from programs.
 from acoupi.system.apps import get_celery_app
 from acoupi.system.celery import (
     get_celery_status,
+    purge_queues,
     restart_workers,
     run_celery_command,
     start_workers,
@@ -59,6 +60,7 @@ __all__ = [
     "enable_services",
     "end_deployment",
     "get_celery_app",
+    "get_celery_status",
     "get_config_field",
     "get_current_deployment",
     "get_status",
@@ -73,6 +75,7 @@ __all__ = [
     "move_recording",
     "parse_config_from_args",
     "profile_task",
+    "purge_queues",
     "restart_workers",
     "run_celery_command",
     "run_task",
@@ -89,5 +92,4 @@ __all__ = [
     "stop_workers",
     "write_config",
     "write_program_file",
-    "get_celery_status",
 ]

--- a/src/acoupi/system/constants.py
+++ b/src/acoupi/system/constants.py
@@ -36,13 +36,69 @@ class Settings(BaseSettings):
 
 
 class CeleryConfig(BaseModel):
-    """Celery config."""
+    """Configuration settings for Celery in Acoupi.
+
+    This class defines the settings used to configure the Celery
+    task queue specifically for the Acoupi application.
+    """
 
     enable_utc: bool = True
+    """Whether to enable UTC for Celery.
+
+    It's generally recommended to keep this enabled for consistency across
+    different Acoupi deployments.
+    """
+
     timezone: str = "UTC"
+    """The timezone to use for Celery."""
+
     broker_url: str = "pyamqp://guest@localhost//"
+    """The URL of the message broker used by Celery.
+
+    Acoupi uses RabbitMQ with the default guest user. You may need to
+    update this if your RabbitMQ setup is different.
+    """
+
     result_backend: str = "rpc://"
+    """ The URL for storing task results. 
+
+    'rpc://' indicates that results are sent back directly to the client.
+    """
+
     result_persistent: bool = False
+    """Whether to persist task results. 
+
+    In Acoupi deployments, task results are not typically needed after the task
+    has completed, as all essential data is stored in an independent database.
+    This setting helps to avoid unnecessary storage overhead.
+    """
+
     task_serializer: str = "pickle"
     result_serializer: str = "pickle"
     accept_content: List[str] = Field(default_factory=lambda: ["pickle"])
+
+    worker_prefetch_multiplier: int = 1
+    """The number of tasks a worker can prefetch.
+
+    Setting this to 1 prevents tasks from being delayed due to other tasks in
+    the queue. Celery defaults to prefetching tasks in batches, which can cause
+    a fast task to wait for a slower one in the same batch.
+    """
+
+    task_soft_time_limit: int = 30
+    """The soft time limit (in seconds) for task execution.
+
+    If a task exceeds this limit, it will receive a warning.
+
+    If you have tasks that are expected to run longer than this limit,
+    you should increase this value or specify the time limit directly.
+    """
+
+    task_time_limit: int = 60
+    """The hard time limit (in seconds) for task execution.
+
+    If a task exceeds this limit, it will be terminated.
+
+    If you have tasks that are expected to run longer than this limit,
+    you should increase this value or specify the time limit directly.
+    """


### PR DESCRIPTION
This PR addresses issue #63 by preventing queue backlogs during deployment startup and improving the handling of long-running tasks.

**Key changes:**

* **Purge Queues on Startup:**
    * Introduced a new `acoupi workers purge` CLI command to clear pending messages in RabbitMQ queues. This command utilizes the `acoupi.system.celery.purge_queues` function. 
    * Integrated the `purge_queues` function into `acoupi deployment start` to ensure a clean slate for new deployments, preventing the carry-over of pending tasks from previous deployments. 

* **Optimized Celery Configuration:**
    * Set `worker_prefetch_multiplier` to `1` in `acoupi.system.constants.CeleryConfig`. Distributes tasks to workers individually, preventing faster tasks from being blocked by slower ones in the same batch (as explained in the Celery documentation: https://docs.celeryq.dev/en/stable/userguide/configuration.html#worker-prefetch-multiplier).
    * Added `task_soft_time_limit=30` and `task_time_limit=60` to `acoupi.system.constants.CeleryConfig`. ets global time limits for tasks to prevent runaway processes and queue buildup. Tasks exceeding 30 seconds receive a warning, and those exceeding 60 seconds are terminated. This approach is recommended for robust queue management (as discussed in: https://medium.com/@taylorhughes/three-quick-tips-from-two-years-with-celery-c05ff9d7f9eb). Time limits can be overridden in specific task definitions if needed.

* **Future Consideration:**

    * As discussed in issue #63, we may need to implement special handling in the file management tasks to address recordings with failed or timed-out detection tasks. This will be addressed in a future update or separate PR.