### PR TITLE
Feat: Default Output Cleaner for DetectionProgram

### DIFF
--- a/docs/howtoguide/programs.md
+++ b/docs/howtoguide/programs.md
@@ -412,6 +412,11 @@ class CustomProgram(DetectionProgram):
 ```
 
 - `get_output_cleaners`: Override this method to define a list of output cleaners that will be applied to the model's raw output to clean it up or extract relevant information.
+    By default, a single cleaner is included: a threshold cleaner.
+    This cleaner removes all detections with a confidence score below a specified threshold.
+    This threshold is configurable via the detections.
+    threshold field in your DetectionProgramConfiguration, enabling you to fine-tune the sensitivity of your detection program at deployment time.
+    You can override this method to add or customize output cleaners according to your specific needs.
 
 - `get_processing_filters`: Override this method to define a list of processing filters that will be applied to each recording before it is processed by the model.
     These filters determine whether a recording should be processed at all.
@@ -421,8 +426,8 @@ For more info on how this program can be configured have a look at its [referenc
 
 ### Predefined Configuration Schemas
 
-Defining a robust configuration schema is crucial for designing effective and adaptable _acoupi_ programs.
-A well-structured schema enhances program flexibility, provides clear guidance to users on configurable options, and ensures that configurations are validated before deployment, preventing potential issues.
+Defining a clear configuration schema is important when designing effective and adaptable _acoupi_ programs.
+A well-structured schema promotes program flexibility, provides clear guidance to users on configurable options, and ensures that configurations are validated before deployment, preventing potential issues.
 
 While you'll need to create custom schemas for program-specific behaviours, _acoupi_ strongly encourages reusing predefined schemas for common components.
 This approach not only saves you time and effort but also ensures compatibility with program templates and benefits from carefully designed and validated schema structures.

--- a/src/acoupi/components/output_cleaners.py
+++ b/src/acoupi/components/output_cleaners.py
@@ -1,17 +1,20 @@
 """ModelOutput cleaners for acoupi.
 
-ModelOutput Cleaners are responsible for cleaning the outputs of a model (i.e., detections) that
-does not meet certain criteria. This can include removing low confidence tags and detections, or
-detections and tags that have a specific labels. The ThresholdDetectionCleaner removes any predictions
+Model Output Cleaners are responsible for cleaning the outputs of a model (i.e.,
+detections) that do not meet certain criteria. This can include removing low
+confidence tags and detections, or detections and tags that have a specific
+labels. For example, the ThresholdDetectionCleaner removes any predictions
 (i.e., detections and tags) with a score below a threshold.
 
-The ModelOutputCleaner is implemented as a class that inherits from ModelOutputCleaner. The class
-should implement the clean method, which takes a data.ModelOutput object and returns
-a cleaned data.ModelOutput object. The modeloutput that does not meet the criteria are removed.
+The ModelOutputCleaner is implemented as a class that inherits from
+ModelOutputCleaner. The class should implement the clean method, which takes a
+data.ModelOutput object and returns a cleaned data.ModelOutput object. The
+modeloutput that does not meet the criteria are removed.
 
-The ModelOutputCleaner is used in the detection task to clean the outputs of the model BEFORE storing
-them in the store. The ModelOutputCleaner is passed to the detection task as a list of ModelOutputCleaner
-objects. This allows to use multiple ModelOutputCleaners to clean the model output.
+The ModelOutputCleaner is used in the detection task to clean the outputs of
+the model BEFORE storing them in the store. The ModelOutputCleaner is passed to
+the detection task as a list of ModelOutputCleaner objects. This allows to use
+multiple ModelOutputCleaners to clean the model output.
 """
 
 from typing import List
@@ -29,40 +32,11 @@ class ThresholdDetectionCleaner(types.ModelOutputCleaner):
     """
 
     detection_threshold: float
-    """The threshold to use to define when a detection is confident vs. unconfident."""
+    """The threshold to use to define when a detection is stored."""
 
     def __init__(self, detection_threshold: float):
         """Initiatlise the filter."""
         self.detection_threshold = detection_threshold
-
-    def get_clean_tags(
-        self, tags: List[data.PredictedTag]
-    ) -> List[data.PredictedTag]:
-        """Remove tags with low score."""
-        return [
-            tag
-            for tag in tags
-            if tag.confidence_score >= self.detection_threshold
-        ]
-
-    def get_clean_detections(
-        self, detections: List[data.Detection]
-    ) -> List[data.Detection]:
-        """Remove detections with low score."""
-        return [
-            self.clean_detection(detection)
-            for detection in detections
-            if detection.detection_score >= self.detection_threshold
-        ]
-
-    def clean_detection(self, detection: data.Detection) -> data.Detection:
-        """Remove tags with low score from detection."""
-        return data.Detection(
-            id=detection.id,
-            location=detection.location,
-            detection_score=detection.detection_score,
-            tags=self.get_clean_tags(detection.tags),
-        )
 
     def clean(self, model_output: data.ModelOutput) -> data.ModelOutput:
         """Clean the model output.
@@ -125,4 +99,33 @@ class ThresholdDetectionCleaner(types.ModelOutputCleaner):
             recording=model_output.recording,
             tags=self.get_clean_tags(model_output.tags),
             detections=self.get_clean_detections(model_output.detections),
+        )
+
+    def get_clean_tags(
+        self, tags: List[data.PredictedTag]
+    ) -> List[data.PredictedTag]:
+        """Remove tags with low score."""
+        return [
+            tag
+            for tag in tags
+            if tag.confidence_score >= self.detection_threshold
+        ]
+
+    def get_clean_detections(
+        self, detections: List[data.Detection]
+    ) -> List[data.Detection]:
+        """Remove detections with low score."""
+        return [
+            self.clean_detection(detection)
+            for detection in detections
+            if detection.detection_score >= self.detection_threshold
+        ]
+
+    def clean_detection(self, detection: data.Detection) -> data.Detection:
+        """Remove tags with low score from detection."""
+        return data.Detection(
+            id=detection.id,
+            location=detection.location,
+            detection_score=detection.detection_score,
+            tags=self.get_clean_tags(detection.tags),
         )

--- a/src/acoupi/programs/templates/__init__.py
+++ b/src/acoupi/programs/templates/__init__.py
@@ -36,6 +36,7 @@ from acoupi.programs.templates.basic import (
 from acoupi.programs.templates.detection import (
     DetectionProgram,
     DetectionProgramConfiguration,
+    DetectionsConfiguration,
 )
 from acoupi.programs.templates.messaging import (
     MessagingConfig,
@@ -50,6 +51,7 @@ __all__ = [
     "BasicProgramConfiguration",
     "DetectionProgram",
     "DetectionProgramConfiguration",
+    "DetectionsConfiguration",
     "MessagingConfig",
     "MessagingProgram",
     "MessagingProgramConfiguration",

--- a/src/acoupi/programs/templates/detection.py
+++ b/src/acoupi/programs/templates/detection.py
@@ -13,7 +13,7 @@ Tasks:
 
 - **Detection Task:** Runs the detection model on audio recordings and
   processes the results, including generating messages based on detected
-  events.
+events. Detections below a specified threshold are ignored.
 
 Features:
 
@@ -110,7 +110,9 @@ class DetectionProgram(MessagingProgram[C], ABC):
 
     - **Detection Task:** Runs the detection model on audio recordings and
       processes the results, including:
-        - Cleaning the model output using `get_output_cleaners`.
+        - Cleaning the model output using `get_output_cleaners`. By default
+        this includes a threshold cleaner that filters out detections below a
+        specified threshold.
         - Filtering the processed output using `get_processing_filters`.
         - Generating messages based on the results using
           `get_message_factories`.
@@ -155,7 +157,9 @@ class DetectionProgram(MessagingProgram[C], ABC):
 
     - `configure_model`:  **Required.** Implement this method to configure
       and return an instance of your detection model.
-    - `get_output_cleaners`:  To clean up the model's raw output.
+    - `get_output_cleaners`:  To clean up the model's raw output. Either
+      override this method completely or call `super().get_output_cleaners()`
+      to include the default threshold cleaner.
     - `get_processing_filters`:  To filter recordings before processing.
     - `get_message_factories`:  To customise the messages generated based on
       detection results.
@@ -280,7 +284,8 @@ class DetectionProgram(MessagingProgram[C], ABC):
 
         This method can be overridden to define a list of output cleaners that
         will be applied to the model's raw output to clean it up or extract
-        relevant information.
+        relevant information. By default, it includes a threshold cleaner that
+        filters out detections below a specified threshold.
 
         Parameters
         ----------

--- a/tests/test_programs/test_detection_template.py
+++ b/tests/test_programs/test_detection_template.py
@@ -2,12 +2,17 @@ from unittest.mock import Mock
 
 import pytest
 from celery import Celery
+from celery.contrib.testing.worker import TestWorkController
 
+from acoupi import data
+from acoupi.components import SqliteStore
 from acoupi.components.audio_recorder import MicrophoneConfig
+from acoupi.components.types import Model
 from acoupi.programs.templates import (
     AudioConfiguration,
     DetectionProgram,
     DetectionProgramConfiguration,
+    DetectionsConfiguration,
     MessagingConfig,
     PathsConfiguration,
 )
@@ -18,11 +23,17 @@ class Config(DetectionProgramConfiguration):
 
 
 @pytest.fixture
+def detection_config() -> DetectionsConfiguration:
+    return DetectionsConfiguration(threshold=0.4)
+
+
+@pytest.fixture
 def config(
     audio_config: AudioConfiguration,
     paths_config: PathsConfiguration,
     microphone_config: MicrophoneConfig,
     messaging_config: MessagingConfig,
+    detection_config: DetectionsConfiguration,
 ) -> Config:
     return Config(
         name="test",
@@ -30,6 +41,7 @@ def config(
         microphone=microphone_config,
         messaging=messaging_config,
         recording=audio_config,
+        detections=detection_config,
     )
 
 
@@ -98,3 +110,95 @@ def test_program_has_all_required_tasks(
     assert "detection_task" in program.tasks
     assert "heartbeat_task" in program.tasks
     assert "send_messages_task" in program.tasks
+
+
+class MockModel(Model):
+    name: str = "test_model"
+
+    def run(self, recording: data.Recording) -> data.ModelOutput:
+        return data.ModelOutput(
+            name_model="test",
+            recording=recording,
+            tags=[
+                data.PredictedTag(
+                    tag=data.Tag(key="species", value="Myotis daubentonii"),
+                    confidence_score=score / 10,
+                )
+                for score in range(11)
+            ],
+            detections=[
+                data.Detection(
+                    detection_score=score / 10,
+                    tags=[
+                        data.PredictedTag(
+                            tag=data.Tag(
+                                key="species", value="Myotis daubentonii"
+                            ),
+                            confidence_score=score2 / 10,
+                        )
+                        for score2 in range(11)
+                    ],
+                )
+                for score in range(11)
+            ],
+        )
+
+
+def test_program_only_stores_detections_with_high_threshold(
+    celery_app: Celery,
+    celery_worker: TestWorkController,
+    config: Config,
+    recording: data.Recording,
+):
+    threshold = 0.6
+
+    class Program(DetectionProgram):
+        config_schema = Config
+
+        def configure_model(self, config):
+            return MockModel()
+
+    config = config.model_copy(
+        update=dict(detections=DetectionsConfiguration(threshold=threshold))
+    )
+
+    program = Program(config, celery_app)
+    celery_worker.reload()
+
+    program.store.store_recording(recording)
+
+    assert "detection_task" in program.tasks
+    program.tasks["detection_task"].delay(recording).get()
+
+    assert isinstance(program.store, SqliteStore)
+
+    outputs = program.store.get_model_outputs(recording_ids=[recording.id])
+    assert len(outputs) == 1
+    output = outputs[0]
+
+    # Check all scores are above threshold
+    assert all(
+        detection.detection_score >= threshold
+        for detection in output.detections
+    )
+    assert all(tag.confidence_score >= threshold for tag in output.tags)
+    assert all(
+        tag.confidence_score >= threshold
+        for detection in output.detections
+        for tag in detection.tags
+    )
+
+    # Check no detection/tag is missed
+    assert (
+        min(detection.detection_score for detection in output.detections)
+        == threshold
+    )
+    assert min(tag.confidence_score for tag in output.tags) == threshold
+    assert (
+        min(
+            tag.confidence_score
+            for detection in output.detections
+            for tag in detection.tags
+        )
+        == threshold
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ requires-python = ">=3.9, <3.13"
 
 [[package]]
 name = "acoupi"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "astral" },
@@ -1280,15 +1280,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.383"
+version = "1.1.389"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/a9/4654d15f4125d8dca6318d7be36a3283a8b3039661291c59bbdd1e576dcf/pyright-1.1.383.tar.gz", hash = "sha256:1df7f12407f3710c9c6df938d98ec53f70053e6c6bbf71ce7bcb038d42f10070", size = 21971 }
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/55/40a6559cea209b551c81dcd31cb351a6ffdb5876e7865ee242e269af72d8/pyright-1.1.383-py3-none-any.whl", hash = "sha256:d864d1182a313f45aaf99e9bfc7d2668eeabc99b29a556b5344894fd73cb1959", size = 18577 },
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR addresses the issue of excessive database growth and performance degradation in the `DetectionProgram` template by introducing a default output cleaner. 

**Problem:**

Deployments using `batdetect2` and `birdnet` demonstrated significant database growth due to the storage of numerous low-score detections. This resulted in increased disk usage and slower database performance, particularly for summary tasks.

**Solution:**

A `ThresholdOutputCleaner` is now included by default in the `DetectionProgram` template. This cleaner discards detections with scores below 0.2, a conservative threshold that retains relevant detections while filtering out noise.

**Implementation:**

* Added `ThresholdOutputCleaner` to the default output cleaners in `DetectionProgram.get_output_cleaners`.
* Introduced a `DetectionConfiguration` schema field with a `threshold` attribute to allow user customization during deployment.
* Added unit tests to verify the functionality of the output cleaner.
* Updated documentation to reflect the changes.