### PR TITLE
Update birdnet and batdetect2 installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The [*acoupi_batdetect2*](https://acoupi.github.io/acoupi_batdetect2/) repositor
 Step 1: Install _acoupi_batdetect2_ program.
 
 ```bash
-uv tool install -w acoupi-batdetect2 -p 3.12 acoupi
+uv tool install -w acoupi-batdetect2 -p 3.11 acoupi
 ```
 
 Step 2: Setup and configure _acoupi_batdetect2_ program.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The [*acoupi_batdetect2*](https://acoupi.github.io/acoupi_batdetect2/) repositor
 Step 1: Install _acoupi_batdetect2_ program.
 
 ```bash
-pip install acoupi_batdetect2
+uv tool install -w acoupi-batdetect2 -p 3.12 acoupi
 ```
 
 Step 2: Setup and configure _acoupi_batdetect2_ program.
@@ -125,7 +125,7 @@ The [*acoupi_birdnet*](https://acoupi.github.io/acoupi_birdnet/) repository prov
 Install _acoupi_birdnet_ program.
 
 ```bash
-pip install acoupi_birdnet
+uv tool install -w acoupi-birdnet -p 3.11 acoupi
 ```
 
 Setup and configure _acoupi_birdnet_ program.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Users should be able to download and test _acoupi_ software on any Linux-based m
 > 
 > The software has been extensively developed and tested with the RPi 4B. We advise users to select the RPi 4B or a device featuring similar specifications.
 
+> [!IMPORTANT]
+> 
+> Although acoupi has been tested across a range of Python versions, using external programs such as those provided by acoupi-birdnet and acoupi-batdetect2 may require a Python version that is compatible with those tools as well.
+> Please refer to their respective documentation for specific installation requirements.
+
 ## Installation
 
 To install and use the bare-bone framework of acoupi on your embedded device follow these steps: 
@@ -108,7 +113,7 @@ The [*acoupi_batdetect2*](https://acoupi.github.io/acoupi_batdetect2/) repositor
 Step 1: Install _acoupi_batdetect2_ program.
 
 ```bash
-uv tool install -w acoupi-batdetect2 -p 3.11 acoupi
+uv tool install -w acoupi-batdetect2 -p 3.12 acoupi
 ```
 
 Step 2: Setup and configure _acoupi_batdetect2_ program.

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ The [**acoupi_batdetect2**](https://github.com/acoupi/acoupi_batdetect2) reposit
 !!! Example "CLI Command: Install _acoupi_batdetect2_ program."
 
     ```bash
-    pip install acoupi_batdetect2
+    uv tool install -w acoupi-batdetect2 -p 3.12 acoupi
     ```
 !!! Example "CLI Command: Setup and configure _acoupi_batdetect2_ program."
 
@@ -113,7 +113,7 @@ The [**acoupi_birdnet**](https://github.com/acoupi/acoupi_birdnet) repository pr
 !!! Example "CLI Command: Install _acoupi_birdnet_ program."
 
     ```bash
-    pip install acoupi_birdnet
+    uv tool install -w acoupi-birdnet -p 3.11 acoupi
     ```
 !!! Example "CLI Command: Setup and configure _acoupi_birdnet_ program."
 


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` for both the `acoupi_batdetect2` and `acoupi_birdnet` programs, replacing `pip install` commands with `uv tool install` commands and specifying Python versions and additional dependencies.

**Updated installation instructions:**

* Changed the installation command for `acoupi_batdetect2` to use `uv tool install` with Python 3.12 and `acoupi-batdetect2`.
* Changed the installation command for `acoupi_birdnet` to use `uv tool install` with Python 3.11 and `acoupi-birdnet`.

Thanks to @timchurches for pointing out this error in #90.