### PR TITLE
Fix/detection worker concurrency #80

### DIFF
--- a/src/acoupi/programs/core/base.py
+++ b/src/acoupi/programs/core/base.py
@@ -145,7 +145,29 @@ class AcoupiProgram(ABC, Generic[ProgramConfig]):
         callback_queue: Optional[str] = None,
         name: Optional[str] = None,
     ):
-        """Add a task to the program."""
+        """Add a task to the program.
+
+        Parameters
+        ----------
+        function :
+            The callable to run as a Celery task.
+        callbacks :
+            Optional list of callables to run after the task completes,
+            receiving the task's return value as their argument.
+        schedule :
+            How often to run the task (timedelta, seconds, or crontab).
+        queue :
+            Name of the queue the task itself should be routed to. Must be
+            declared in the program's ``worker_config``.
+        callback_queue :
+            Name of the queue all callbacks should be routed to. Must be
+            declared in the program's ``worker_config``. When set, every
+            callback is registered in ``app.conf.task_routes`` so that
+            ``apply_async()`` dispatches it to the correct worker without
+            needing an explicit queue argument at call-site.
+        name :
+            Celery task name. Defaults to ``function.__name__``.
+        """
         if not callbacks:
             callbacks = []
 

--- a/src/acoupi/programs/core/base.py
+++ b/src/acoupi/programs/core/base.py
@@ -142,6 +142,7 @@ class AcoupiProgram(ABC, Generic[ProgramConfig]):
         callbacks: Optional[List[Callable[[Optional[B]], None]]] = None,
         schedule: Union[int, datetime.timedelta, crontab, None] = None,
         queue: Optional[str] = None,
+        callback_queue: Optional[str] = None,
         name: Optional[str] = None,
     ):
         """Add a task to the program."""
@@ -159,6 +160,10 @@ class AcoupiProgram(ABC, Generic[ProgramConfig]):
 
             # get the task from the list of tasks
             callback_task = self.tasks[callback.__name__]
+
+            if callback_queue:
+                # route the callback task to the callback queue
+                self.add_task_to_queue(callback_task.name, callback_queue)
 
             # add the task to the list of callback tasks
             callback_tasks.append(callback_task)

--- a/src/acoupi/programs/templates/detection.py
+++ b/src/acoupi/programs/templates/detection.py
@@ -229,7 +229,13 @@ class DetectionProgram(MessagingProgram[C], ABC):
     ) -> None:
         """Register the recording task.
 
-        This method registers the recording task with the program's scheduler.
+        Overrides ``BasicProgram.register_recording_task`` to route detection
+        callbacks to the dedicated ``"detection"`` worker (concurrency=1),
+        preventing OOM from parallel model loads.
+
+        Note: intentionally does not call ``super()`` — the base
+        implementation would register the same recording task without the
+        ``callback_queue`` argument, leaving callbacks unrouted.
         """
         recording_task = self.create_recording_task(config)
         self.add_task(

--- a/src/acoupi/programs/templates/detection.py
+++ b/src/acoupi/programs/templates/detection.py
@@ -46,6 +46,7 @@ To create an Acoupi program with audio detection capabilities:
       detection results.
 """
 
+import datetime
 from abc import ABC, abstractmethod
 from typing import Callable, List, TypeVar
 
@@ -53,6 +54,7 @@ from pydantic import BaseModel, Field
 
 from acoupi import data
 from acoupi.components import ThresholdDetectionCleaner, types
+from acoupi.programs.core.workers import AcoupiWorker, WorkerConfig
 from acoupi.programs.templates.messaging import (
     MessagingProgram,
     MessagingProgramConfiguration,
@@ -199,8 +201,44 @@ class DetectionProgram(MessagingProgram[C], ABC):
     ```
     """
 
+    worker_config = WorkerConfig(
+        workers=[
+            AcoupiWorker(
+                name="recording",
+                queues=["recording"],
+                concurrency=1,
+            ),
+            AcoupiWorker(
+                name="detection",
+                queues=["detection"],
+                concurrency=1,
+            ),
+            AcoupiWorker(
+                name="default",
+                queues=["celery"],
+            ),
+        ]
+    )
+
     model: types.Model
     """The configured detection model instance."""
+
+    def register_recording_task(
+        self,
+        config: C,
+    ) -> None:
+        """Register the recording task.
+
+        This method registers the recording task with the program's scheduler.
+        """
+        recording_task = self.create_recording_task(config)
+        self.add_task(
+            function=recording_task,
+            schedule=datetime.timedelta(seconds=config.recording.interval),
+            callbacks=self.get_recording_callbacks(config),
+            queue="recording",
+            callback_queue="detection",
+        )
 
     def setup(self, config: C) -> None:
         """Set up the Detection Program.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,23 @@ from acoupi.system import Settings
 pytest_plugins = ("celery.contrib.pytest",)
 
 
+@pytest.fixture(scope="session")
+def celery_config():
+    return {
+        "broker_url": "memory://",
+        "result_backend": "rpc://",
+        "broker_transport_options": {"polling_interval": 0.05},
+    }
+
+
+@pytest.fixture(scope="session")
+def celery_parameters():
+    return {
+        "broker_url": "memory://",
+        "result_backend": "rpc://",
+    }
+
+
 @pytest.fixture
 def patched_rpi_serial_number(monkeypatch) -> str:
     """Patch the RPi serial number.

--- a/tests/test_programs/test_detection_template.py
+++ b/tests/test_programs/test_detection_template.py
@@ -144,6 +144,63 @@ class MockModel(Model):
         )
 
 
+def test_worker_config_has_dedicated_detection_worker():
+    workers = {w.name: w for w in DetectionProgram.worker_config.workers}
+    assert "detection" in workers, "DetectionProgram must declare a 'detection' worker"
+    assert workers["detection"].concurrency == 1, (
+        "detection worker must have concurrency=1 to prevent OOM from parallel model loads"
+    )
+    assert workers["recording"].concurrency == 1, (
+        "recording worker must have concurrency=1 (audio device is not thread-safe)"
+    )
+
+
+@pytest.mark.usefixtures("celery_app")
+def test_detection_task_is_routed_to_detection_queue(
+    celery_app: Celery,
+    config: Config,
+):
+    class Program(DetectionProgram):
+        config_schema = Config
+
+        def configure_model(self, config):
+            return Mock()
+
+    Program(config, celery_app)
+
+    routes = celery_app.conf.task_routes or {}
+    assert routes.get("detection_task") == {"queue": "detection"}, (
+        "detection_task must be routed to the 'detection' queue so that "
+        "apply_async() dispatches it to the concurrency=1 worker"
+    )
+
+
+@pytest.mark.usefixtures("celery_app")
+def test_unknown_callback_queue_raises_at_setup(
+    celery_app: Celery,
+    config: Config,
+):
+    """Passing a callback_queue not in worker_config must fail early."""
+
+    class Program(DetectionProgram):
+        config_schema = Config
+
+        def configure_model(self, config):
+            return Mock()
+
+        def register_recording_task(self, config):
+            recording_task = self.create_recording_task(config)
+            self.add_task(
+                function=recording_task,
+                callbacks=self.get_recording_callbacks(config),
+                queue="recording",
+                callback_queue="nonexistent_queue",
+            )
+
+    with pytest.raises(ValueError, match="nonexistent_queue"):
+        Program(config, celery_app)
+
+
 def test_program_only_stores_detections_with_high_threshold(
     celery_app: Celery,
     celery_worker: TestWorkController,


### PR DESCRIPTION
This is to fix #80 by adding a dedicated detection worker with `concurrency=1` and route detection callbacks to it. 

This should ensure:
- Recordings continue unblocked (separate `recording` worker, unchanged)
- Detections run one at a time (no OOM from parallel model loading)
- If inference is slow, the detection queue grows, but recordings continue
- The disk-fill problem (issue #81) is not solved by this fix, but is decoupled and manageable

Let me know if this is workable - I am currently testing this on a Pi4B in South Australia.