### PR TITLE
Add GUANO metadata to recordings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "pygments>=2.18.0",
   "pydantic-extra-types>=2.9.0",
   "omegaconf>=2.3.0",
+  "guano>=1.0.16",
 ]
 requires-python = ">=3.9,<3.14"
 readme = "README.md"

--- a/src/acoupi/tasks/recording.py
+++ b/src/acoupi/tasks/recording.py
@@ -13,8 +13,12 @@ The recording process contains the following steps:
 import logging
 from typing import Callable, List, Optional, TypeVar
 
+from guano import GuanoFile
+from importlib_metadata import version
+
 from acoupi import data
 from acoupi.components import types
+from acoupi.devices import get_rpi_serial_number
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -93,6 +97,9 @@ def generate_recording_task(
         logger.info("Recording audio")
         recording = recorder.record(deployment)
 
+        logger.info("Adding GUANO metadata")
+        add_guano_metadata(recording)
+
         # Store recording metadata
         store.store_recording(recording)
         logger.info("Recording metadata stored")
@@ -100,3 +107,25 @@ def generate_recording_task(
         return recording
 
     return recording_task
+
+
+def add_guano_metadata(recording: data.Recording) -> None:
+    g = GuanoFile(str(recording.path))
+
+    g["GUANO|Version"] = "1.0"
+    g["Timestamp"] = recording.created_on
+    g["Acoupi|Deployment Name"] = recording.deployment.name
+    g["Firmware Version"] = version("acoupi")
+    g["Make"] = "acoupi"
+    g["Serial"] = get_rpi_serial_number()
+
+    if (
+        recording.deployment.longitude is not None
+        and recording.deployment.latitude is not None
+    ):
+        g["Loc Position"] = (
+            recording.deployment.latitude,
+            recording.deployment.longitude,
+        )
+
+    g.write()

--- a/tests/test_tasks/conftest.py
+++ b/tests/test_tasks/conftest.py
@@ -1,0 +1,29 @@
+import wave
+from pathlib import Path
+from typing import Optional
+
+from guano import GuanoFile
+
+
+def create_wav_file(
+    path: Path,
+    samplerate: int = 16000,
+) -> Path:
+    with wave.open(str(path), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(samplerate)
+        wav_file.writeframes(b"\x00\x00" * samplerate)
+
+    return path
+
+
+def write_guano_chunk(path: Path, metadata: str) -> None:
+    g = GuanoFile(str(path))
+    g["Note"] = metadata
+    g.write()
+
+
+def read_guano_chunk(path: Path) -> Optional[str]:
+    g = GuanoFile(str(path))
+    return g.get("Note")

--- a/tests/test_tasks/test_management_task.py
+++ b/tests/test_tasks/test_management_task.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 
 import pytest
 
+from .conftest import create_wav_file, read_guano_chunk, write_guano_chunk
 from acoupi import data
 from acoupi.components import SqliteStore
 from acoupi.components.types import (
@@ -206,3 +207,41 @@ def test_file_management_deletes_files_that_do_not_pass_filters(
     assert recording.path is not None
     assert not recording.path.exists()
     assert not (target_dir / recording.path.name).exists()
+
+
+def test_file_management_preserves_existing_guano_metadata(
+    target_dir: Path,
+    temp_audio_dir: Path,
+    dummy_manager: DummyRecordingManager,
+    deployment: data.Deployment,
+    store: SqliteStore,
+):
+    recording_path = temp_audio_dir / "test.wav"
+    create_wav_file(recording_path)
+    write_guano_chunk(recording_path, "Hi from acoupi!")
+
+    recording = data.Recording(
+        path=recording_path,
+        duration=1,
+        samplerate=16000,
+        audio_channels=1,
+        created_on=datetime.datetime.now(),
+        deployment=deployment,
+    )
+    store.store_recording(recording)
+
+    task = generate_file_management_task(
+        store=store,
+        file_managers=[dummy_manager],
+        tmp_path=temp_audio_dir,
+    )
+
+    task()
+
+    saved_recording, _ = store.get_recordings([recording.id])[0]
+    assert saved_recording.path is not None
+    assert saved_recording.path.exists()
+    assert saved_recording.path.is_relative_to(target_dir)
+    guano_text = read_guano_chunk(saved_recording.path)
+    assert guano_text is not None
+    assert "Hi from acoupi!" in guano_text

--- a/tests/test_tasks/test_recording_task.py
+++ b/tests/test_tasks/test_recording_task.py
@@ -1,0 +1,109 @@
+"""Test suite for the recording task generator."""
+
+import datetime
+from pathlib import Path
+
+from guano import GuanoFile
+from importlib_metadata import version
+
+from .conftest import create_wav_file
+from acoupi import data
+from acoupi.components import SqliteStore
+from acoupi.components.types import AudioRecorder
+from acoupi.devices import get_rpi_serial_number
+from acoupi.tasks import generate_recording_task
+
+
+class DummyRecorder(AudioRecorder):
+    def __init__(
+        self,
+        path: Path,
+        created_on: datetime.datetime,
+        samplerate: int = 16000,
+        duration: float = 1.0,
+    ):
+        self.path = path
+        self.created_on = created_on
+        self.samplerate = samplerate
+        self.duration = duration
+
+    def record(self, deployment: data.Deployment) -> data.Recording:
+        create_wav_file(self.path, samplerate=self.samplerate)
+        return data.Recording(
+            path=self.path,
+            created_on=self.created_on,
+            duration=self.duration,
+            samplerate=self.samplerate,
+            audio_channels=1,
+            chunksize=1024,
+            deployment=deployment,
+        )
+
+
+def test_recording_task_writes_guano_metadata_with_location(tmp_path: Path):
+    deployment = data.Deployment(
+        name="field-site-a",
+        latitude=51.5072,
+        longitude=-0.1276,
+        started_on=datetime.datetime(2024, 1, 1, 0, 0, 0),
+    )
+    created_on = datetime.datetime(2024, 8, 4, 5, 6, 7)
+
+    store = SqliteStore(tmp_path / "metadata.db")
+    store.store_deployment(deployment)
+
+    recorder = DummyRecorder(
+        path=tmp_path / "recording.wav",
+        created_on=created_on,
+    )
+
+    task = generate_recording_task(recorder=recorder, store=store)
+
+    recording = task()
+
+    assert recording is not None
+    assert recording.path is not None
+
+    g = GuanoFile(str(recording.path))
+
+    assert g["GUANO|Version"] == "1.0"
+    assert g["Timestamp"] == created_on.isoformat()
+    assert g["Acoupi|Deployment Name"] == deployment.name
+    assert g["Acoupi|Deployment ID"] == deployment.id
+    assert g["Loc Position"] == f"{deployment.latitude} {deployment.longitude}"
+    assert g["Firmware Version"] == version("acoupi")
+    assert g["Make"] == "acoupi"
+    assert g["Serial"] == get_rpi_serial_number()
+
+
+def test_recording_task_writes_guano_metadata_without_location(
+    tmp_path: Path,
+):
+    deployment = data.Deployment(
+        name="field-site-b",
+        started_on=datetime.datetime(2024, 1, 1, 0, 0, 0),
+    )
+    created_on = datetime.datetime(2024, 8, 4, 5, 6, 7)
+
+    store = SqliteStore(tmp_path / "metadata.db")
+    store.store_deployment(deployment)
+
+    recorder = DummyRecorder(
+        path=tmp_path / "recording.wav",
+        created_on=created_on,
+    )
+
+    task = generate_recording_task(recorder=recorder, store=store)
+
+    recording = task()
+
+    assert recording is not None
+    assert recording.path is not None
+
+    g = GuanoFile(str(recording.path))
+
+    assert g["GUANO|Version"] == "1.0"
+    assert g["Timestamp"] == created_on.isoformat()
+    assert g["Acoupi|Deployment Name"] == deployment.name
+    assert g["Acoupi|Deployment ID"] == deployment.id
+    assert "Loc Position" not in g

--- a/tests/test_tasks/test_recording_task.py
+++ b/tests/test_tasks/test_recording_task.py
@@ -10,7 +10,6 @@ from .conftest import create_wav_file
 from acoupi import data
 from acoupi.components import SqliteStore
 from acoupi.components.types import AudioRecorder
-from acoupi.devices import get_rpi_serial_number
 from acoupi.tasks import generate_recording_task
 
 
@@ -40,7 +39,15 @@ class DummyRecorder(AudioRecorder):
         )
 
 
-def test_recording_task_writes_guano_metadata_with_location(tmp_path: Path):
+def test_recording_task_writes_guano_metadata_with_location(
+    tmp_path: Path,
+    mocker,
+):
+    mocker.patch(
+        "acoupi.tasks.recording.get_rpi_serial_number",
+        return_value="1234567890ABCDEF",
+    )
+
     deployment = data.Deployment(
         name="field-site-a",
         latitude=51.5072,
@@ -67,18 +74,23 @@ def test_recording_task_writes_guano_metadata_with_location(tmp_path: Path):
     g = GuanoFile(str(recording.path))
 
     assert g["GUANO|Version"] == "1.0"
-    assert g["Timestamp"] == created_on.isoformat()
+    assert g["Timestamp"] == created_on
     assert g["Acoupi|Deployment Name"] == deployment.name
-    assert g["Acoupi|Deployment ID"] == deployment.id
-    assert g["Loc Position"] == f"{deployment.latitude} {deployment.longitude}"
+    assert g["Loc Position"] == (deployment.latitude, deployment.longitude)
     assert g["Firmware Version"] == version("acoupi")
     assert g["Make"] == "acoupi"
-    assert g["Serial"] == get_rpi_serial_number()
+    assert g["Serial"] == "1234567890ABCDEF"
 
 
 def test_recording_task_writes_guano_metadata_without_location(
     tmp_path: Path,
+    mocker,
 ):
+    mocker.patch(
+        "acoupi.tasks.recording.get_rpi_serial_number",
+        return_value="1234567890ABCDEF",
+    )
+
     deployment = data.Deployment(
         name="field-site-b",
         started_on=datetime.datetime(2024, 1, 1, 0, 0, 0),
@@ -103,7 +115,6 @@ def test_recording_task_writes_guano_metadata_without_location(
     g = GuanoFile(str(recording.path))
 
     assert g["GUANO|Version"] == "1.0"
-    assert g["Timestamp"] == created_on.isoformat()
+    assert g["Timestamp"] == created_on
     assert g["Acoupi|Deployment Name"] == deployment.name
-    assert g["Acoupi|Deployment ID"] == deployment.id
-    assert "Loc Position" not in g
+    assert "Loc Position" not in g, g["Loc Position"]

--- a/uv.lock
+++ b/uv.lock
@@ -21,7 +21,7 @@ wheels = [
 
 [[package]]
 name = "acoupi"
-version = "0.3.0"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "astral" },
@@ -29,6 +29,7 @@ dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "click", version = "8.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "eventlet" },
+    { name = "guano" },
     { name = "jinja2" },
     { name = "omegaconf" },
     { name = "paho-mqtt" },
@@ -83,6 +84,7 @@ requires-dist = [
     { name = "celery", specifier = ">=5.4.0" },
     { name = "click", specifier = ">=8.1.3" },
     { name = "eventlet", specifier = ">=0.36.1" },
+    { name = "guano", specifier = ">=1.0.16" },
     { name = "jinja2", specifier = ">=3.1.2" },
     { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "paho-mqtt", specifier = ">=1.6.1" },
@@ -995,6 +997,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0d/0c/3a471b6e31951dce2360477420d0a8d1e00dea6cf33b70f3e8c3ab6e28e1/griffe-1.15.0.tar.gz", hash = "sha256:7726e3afd6f298fbc3696e67958803e7ac843c1cfe59734b6251a40cdbfb5eea", size = 424112, upload-time = "2025-11-10T15:03:15.52Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl", hash = "sha256:6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3", size = 150705, upload-time = "2025-11-10T15:03:13.549Z" },
+]
+
+[[package]]
+name = "guano"
+version = "1.0.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/44/86b184759934b224699f24769c95c8ea8e22c1216f07f1828bc721ce5418/guano-1.0.16.tar.gz", hash = "sha256:59b418bf15f858f5708ab81d8c8503c757f9b52875d3ab5873ad9663b220f636", size = 19515, upload-time = "2025-03-09T05:21:27.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/7b/c5a4ccb080bb3a19b2392bff4856fff750ee29ae3cc401a331aedfb633cb/guano-1.0.16-py2.py3-none-any.whl", hash = "sha256:e0038732d26466e641db221b74a3560cd5ac956150077d1efccb9427a0d02158", size = 21645, upload-time = "2025-03-09T05:21:26.076Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR adds initial support for writing GUANO metadata into recorded WAV files.

The goal is to start embedding useful recording context directly in the audio file so that metadata can travel with the recording, rather than only being stored separately in the database.

## What changed

- added the `guano` dependency
- updated the recording task to write a GUANO chunk after a recording is created
- added the following metadata to the GUANO chunk:
  - `GUANO|Version`
  - `Timestamp`
  - `Acoupi|Deployment Name`
  - `Firmware Version`
  - `Make`
  - `Serial`
  - `Loc Position` when deployment latitude/longitude are available
- added tests covering:
  - GUANO metadata being written for new recordings
  - behaviour with and without deployment location
  - preservation of existing GUANO metadata during file management

## Why

This is a first step towards making recordings more self-describing and easier to work with outside of Acoupi. Embedding metadata in the WAV file should make downstream handling, sharing, and inspection simpler.

## Feedback wanted

I’d especially like feedback on the GUANO metadata itself:
- is this the right starting set of fields?
- are there important fields we should add or rename?
- should we keep this minimal, or include more Acoupi-specific metadata?

## Acknowledgements

Thanks to @timchurches for suggesting the feature in #93 
