### PR TITLE
Fixing TLS MQTT Connection

### DIFF
--- a/src/acoupi/components/messengers.py
+++ b/src/acoupi/components/messengers.py
@@ -110,6 +110,7 @@ class MQTTMessenger(types.Messenger):
         if use_tls:
             # Calling tls_set() without arguments uses the system's 
             # default CA certificates, which works for HiveHQ
+            self.logger.warning(f"Using TLS Connection.")
             self.client.tls_set()
 
         self.client.username_pw_set(username, password)

--- a/src/acoupi/components/messengers.py
+++ b/src/acoupi/components/messengers.py
@@ -106,19 +106,19 @@ class MQTTMessenger(types.Messenger):
             client_id=self.client_id,
             clean_session=False,
         )
-
-        if use_tls:
-            # Calling tls_set() without arguments uses the system's 
-            # default CA certificates, which works for HiveHQ
-            self.logger.warning(f"Using TLS Connection.")
-            self.client.tls_set()
-
+        
         self.client.username_pw_set(username, password)
 
         if logger is None:
             logger = get_task_logger(__name__)
 
         self.logger = logger
+
+        if use_tls:
+            # Calling tls_set() without arguments uses the system's 
+            # default CA certificates, which works for HiveHQ
+            self.logger.info(f"Using TLS Connection.")
+            self.client.tls_set()
 
     @classmethod
     def from_config(

--- a/src/acoupi/components/messengers.py
+++ b/src/acoupi/components/messengers.py
@@ -43,6 +43,7 @@ class MQTTConfig(BaseModel):
     topic: str = "acoupi"
     port: int = 1884
     timeout: int = 5
+    use_tls: bool = False
 
     @field_serializer("password", when_used="json")
     def dump_password(self, value):
@@ -137,6 +138,7 @@ class MQTTMessenger(types.Messenger):
             else None,
             topic=config.topic,
             timeout=config.timeout,
+            use_tls=config.use_tls,
             logger=logger,
         )
 

--- a/src/acoupi/components/messengers.py
+++ b/src/acoupi/components/messengers.py
@@ -100,6 +100,7 @@ class MQTTMessenger(types.Messenger):
         self.host = host
         self.port = port
         self.client_id = get_device_id()
+        self.use_tls = use_tls
 
         self.client = mqtt.Client(
             callback_api_version=CallbackAPIVersion.VERSION2,

--- a/src/acoupi/components/messengers.py
+++ b/src/acoupi/components/messengers.py
@@ -71,6 +71,7 @@ class MQTTMessenger(types.Messenger):
         username: Optional[str] = None,
         password: Optional[str] = None,
         timeout: int = 5,
+        use_tls: bool = False,
         logger: Optional[logging.Logger] = None,
     ) -> None:
         """Initialise the MQTT messenger.
@@ -87,6 +88,8 @@ class MQTTMessenger(types.Messenger):
             The port to connect to, by default 1884.
         password : Optional[SecretStr], optional
             The password to authenticate with, by default None.
+        use_tls: bool
+            Use TLS is host requires this with local certs (eg. HiveHQ) - default sets to false
 
         Notes
         -----
@@ -103,6 +106,11 @@ class MQTTMessenger(types.Messenger):
             client_id=self.client_id,
             clean_session=False,
         )
+
+        if use_tls:
+            # Calling tls_set() without arguments uses the system's 
+            # default CA certificates, which works for HiveHQ
+            self.client.tls_set()
 
         self.client.username_pw_set(username, password)
 

--- a/src/acoupi/components/messengers.py
+++ b/src/acoupi/components/messengers.py
@@ -114,7 +114,7 @@ class MQTTMessenger(types.Messenger):
 
         self.logger = logger
 
-        if use_tls:
+        if self.use_tls:
             # Calling tls_set() without arguments uses the system's 
             # default CA certificates, which works for HiveHQ
             self.logger.info(f"Using TLS Connection.")


### PR DESCRIPTION
This PR will fix a situation where the broker needs TLS (such as the default HiveMQ broker).  Adds a "use_tls" variable into the main program.json setup file.  Code detects if the variable is present before trying to set and log.  

```
"mqtt": {
      "host": "",
      "username": "",
      "password": "",
      "topic": "",
      "port": 8883,
      "use_tls": true,
      "timeout": 5
    }
```