### PR TITLE
Add storage space recording condition and tests

### DIFF
--- a/src/acoupi/components/recording_conditions.py
+++ b/src/acoupi/components/recording_conditions.py
@@ -12,17 +12,22 @@ which returns a boolean indicating if a recording should be made.
 """
 
 import datetime
-from typing import List
+import shutil
+from pathlib import Path
+from typing import List, Literal
 
 from astral import LocationInfo
 from astral.sun import sun
 
 from acoupi import data
 from acoupi.components import types
+from acoupi.components.audio_recorder import TMP_PATH
 
 __all__ = [
     "IsInInterval",
     "IsInIntervals",
+    "DawnTimeInterval",
+    "HasSufficientSpace",
 ]
 
 
@@ -190,3 +195,60 @@ class DawnTimeInterval(types.RecordingCondition):
         return (
             start_dawninterval.time() <= now.time() <= end_dawninterval.time()
         )
+
+
+class HasSufficientSpace(types.RecordingCondition):
+    """A RecordingCondition that checks available disk space."""
+
+    def __init__(
+        self,
+        path: Path = TMP_PATH,
+        min_space: int = 1024,
+        unit: Literal["B", "KB", "MB", "GB"] = "MB",
+        binary: bool = False,
+    ):
+        """Initialise the storage-space recording condition.
+
+        Parameters
+        ----------
+        path : Path
+            The path whose filesystem free space should be checked.
+        min_space : int
+            The minimum free space required to allow recording.
+        unit : Literal["B", "KB", "MB", "GB"]
+            The unit used for ``min_space``. By default MB.
+        binary : bool
+            Whether to use powers of 1024 instead of 1000 when converting units.
+        """
+        self.path = path
+        self.unit = unit
+
+        self.min_space = _to_bytes(min_space, unit, binary=binary)
+
+    def should_record(self) -> bool:
+        """Return whether the target filesystem has enough free space."""
+        info = shutil.disk_usage(self.path)
+        return info.free > self.min_space
+
+
+def _to_bytes(
+    size: int,
+    unit: Literal["B", "KB", "MB", "GB"],
+    binary: bool = False,
+) -> int:
+    """Convert a size value in the given unit to bytes."""
+    if unit == "B":
+        return size
+
+    base = 1024 if binary else 1000
+
+    if unit == "KB":
+        return size * base
+
+    if unit == "MB":
+        return size * base**2
+
+    if unit == "GB":
+        return size * base**3
+
+    raise ValueError(f"Invalid unit {unit}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,25 +13,22 @@ import pytest
 
 from acoupi import data
 from acoupi.system import Settings
+from acoupi.system.constants import CeleryConfig
 
 pytest_plugins = ("celery.contrib.pytest",)
 
 
 @pytest.fixture(scope="session")
 def celery_config():
-    return {
-        "broker_url": "memory://",
-        "result_backend": "rpc://",
-        "broker_transport_options": {"polling_interval": 0.05},
-    }
+    return CeleryConfig(
+        broker_url="memory://",
+        result_backend="cache+memory://",
+    ).model_dump()
 
 
 @pytest.fixture(scope="session")
 def celery_parameters():
-    return {
-        "broker_url": "memory://",
-        "result_backend": "rpc://",
-    }
+    return {"broker_url": "memory://", "result_backend": "cache+memory://"}
 
 
 def celery_enable_logging():

--- a/tests/test_components/test_recording_conditions.py
+++ b/tests/test_components/test_recording_conditions.py
@@ -1,8 +1,10 @@
 """Test the recording conditions."""
 
+import collections
 import datetime
 
 from acoupi import components, data
+from acoupi.components.recording_conditions import HasSufficientSpace
 
 
 def test_single_interval_recording_manager(patched_now):
@@ -76,3 +78,49 @@ def test_multiple_interval_recording_manager(patched_now):
 
     patched_now(now.replace(hour=12, minute=59))
     assert recording_manager.should_record() is True
+
+
+class TestHasSufficientSpace:
+    def test_space_true(self, mocker):
+        usage = collections.namedtuple("usage", ["total", "used", "free"])
+        mocker.patch(
+            "acoupi.components.recording_conditions.shutil.disk_usage",
+            return_value=usage(total=10, used=4, free=1_000_001),
+        )
+
+        condition = HasSufficientSpace(min_space=1, unit="MB")
+
+        assert condition.should_record() is True
+
+    def test_space_false(self, mocker):
+        usage = collections.namedtuple("usage", ["total", "used", "free"])
+        mocker.patch(
+            "acoupi.components.recording_conditions.shutil.disk_usage",
+            return_value=usage(total=10, used=4, free=999_999),
+        )
+
+        condition = HasSufficientSpace(min_space=1, unit="MB")
+
+        assert condition.should_record() is False
+
+    def test_space_equal_false(self, mocker):
+        usage = collections.namedtuple("usage", ["total", "used", "free"])
+        mocker.patch(
+            "acoupi.components.recording_conditions.shutil.disk_usage",
+            return_value=usage(total=10, used=4, free=1_000_000),
+        )
+
+        condition = HasSufficientSpace(min_space=1, unit="MB")
+
+        assert condition.should_record() is False
+
+    def test_space_binary(self, mocker):
+        usage = collections.namedtuple("usage", ["total", "used", "free"])
+        mocker.patch(
+            "acoupi.components.recording_conditions.shutil.disk_usage",
+            return_value=usage(total=10, used=4, free=1_048_577),
+        )
+
+        condition = HasSufficientSpace(min_space=1, unit="MB", binary=True)
+
+        assert condition.should_record() is True

--- a/tests/test_components/test_recording_conditions.py
+++ b/tests/test_components/test_recording_conditions.py
@@ -103,17 +103,6 @@ class TestHasSufficientSpace:
 
         assert condition.should_record() is False
 
-    def test_space_equal_false(self, mocker):
-        usage = collections.namedtuple("usage", ["total", "used", "free"])
-        mocker.patch(
-            "acoupi.components.recording_conditions.shutil.disk_usage",
-            return_value=usage(total=10, used=4, free=1_000_000),
-        )
-
-        condition = HasSufficientSpace(min_space=1, unit="MB")
-
-        assert condition.should_record() is False
-
     def test_space_binary(self, mocker):
         usage = collections.namedtuple("usage", ["total", "used", "free"])
         mocker.patch(

--- a/tests/test_programs/conftest.py
+++ b/tests/test_programs/conftest.py
@@ -13,13 +13,6 @@ from acoupi.system.constants import CeleryConfig
 
 
 @pytest.fixture(scope="session")
-def celery_config():
-    return CeleryConfig(
-        result_backend="cache+memory://",
-    ).model_dump()
-
-
-@pytest.fixture(scope="session")
 def celery_worker_parameters():
     """Redefine this fixture to change the init parameters of Celery workers.
 


### PR DESCRIPTION
## Summary

This PR adds a new recording condition to check that there is enough free disk space before starting a recording.

It also adds simple unit tests for the new condition and updates the test Celery config to use a consistent in-memory backend.

## Changes

- add `HasSufficientSpace` recording condition
- add tests for:
  - enough free space
  - not enough free space
  - binary unit conversion
- harmonize Celery test config in shared test fixtures

## Testing

- `pytest tests/test_components/test_recording_conditions.py`