### PR TITLE
Support byte message payloads and separate send failures from remote errors

### DIFF
--- a/src/acoupi/components/message_factories.py
+++ b/src/acoupi/components/message_factories.py
@@ -10,8 +10,8 @@ when connectivity is limited. For example, message factories
 can be used to filter detections with low score.
 
 Message factories are implemented as classes that inherit from MessageBuilder. The class should
-implement the build_message method, which takes a model output and returns a message. The message
-should be a JSON string containing the information to be sent to the remote server.
+implement the build_message method, which takes a model output and returns a message. Built-in
+message factories emit JSON text, but custom factories may emit raw bytes for binary transports.
 """
 
 from typing import List, Optional
@@ -29,7 +29,7 @@ class DetectionThresholdMessageBuilder(types.MessageBuilder):
     """A MessageBuilder that builds message from model outputs.
 
     This message builder builds a message from a model output. The created
-    message will contain the full model output as a JSON string. This
+    message will contain the full model output as JSON text. This
     includes information about the model used, the recording including deployment info,
     and the detections and predicted tags that meet the threshold.
     """
@@ -125,7 +125,7 @@ class FullModelOutputMessageBuilder(types.MessageBuilder):
     """A MessageBuilder that builds message from model outputs.
 
     This message builder builds a message from a model output. The created
-    message will contain the full model output as a JSON string.
+    message will contain the full model output as JSON text.
     """
 
     def build_message(self, model_output: data.ModelOutput) -> data.Message:

--- a/src/acoupi/components/message_stores/sqlite/database.py
+++ b/src/acoupi/components/message_stores/sqlite/database.py
@@ -20,7 +20,7 @@ def create_message_models(
         id = orm.PrimaryKey(UUID, auto=True)
         """Unique ID of the message status"""
 
-        content = orm.Required(str)
+        content = orm.Required(bytes)
         """Message content."""
 
         created_on = orm.Required(datetime)

--- a/src/acoupi/components/message_stores/sqlite/message_store.py
+++ b/src/acoupi/components/message_stores/sqlite/message_store.py
@@ -1,7 +1,7 @@
 """Message store Sqlite implementation."""
 
 from pathlib import Path
-from typing import List
+from typing import List, Union
 
 from pony import orm
 
@@ -9,6 +9,7 @@ from . import types as db_types
 from .database import create_message_models
 from acoupi import data
 from acoupi.components import types
+from acoupi.system.exceptions import MessageStoreError
 
 
 class SqliteMessageStore(types.MessageStore):
@@ -77,7 +78,9 @@ class SqliteMessageStore(types.MessageStore):
         try:
             db_message = self.models.Message[response.message.id]
         except orm.ObjectNotFound:
-            db_message = self._create_message(response.message)
+            raise MessageStoreError(
+                f"Cannot store response for unknown message {response.message.id}."
+            )
 
         self.models.Response(
             message=db_message,
@@ -95,8 +98,16 @@ class SqliteMessageStore(types.MessageStore):
         """Create a Pony ORM message object."""
         db_message = self.models.Message(
             id=message.id,
-            content=message.content,
+            content=self._as_bytes(message.content),
             created_on=message.created_on,
         )
         orm.commit()
         return db_message
+
+    @staticmethod
+    def _as_bytes(content: Union[str, bytes]) -> bytes:
+        """Normalise message content to bytes for storage."""
+        if isinstance(content, bytes):
+            return content
+
+        return content.encode("utf-8")

--- a/src/acoupi/components/message_stores/sqlite/message_store.py
+++ b/src/acoupi/components/message_stores/sqlite/message_store.py
@@ -77,10 +77,10 @@ class SqliteMessageStore(types.MessageStore):
         """Store a response to a message."""
         try:
             db_message = self.models.Message[response.message.id]
-        except orm.ObjectNotFound:
+        except orm.ObjectNotFound as error:
             raise MessageStoreError(
                 f"Cannot store response for unknown message {response.message.id}."
-            )
+            ) from error
 
         self.models.Response(
             message=db_message,

--- a/src/acoupi/components/message_stores/sqlite/types.py
+++ b/src/acoupi/components/message_stores/sqlite/types.py
@@ -13,7 +13,7 @@ class Message(core.EntityMeta):
     id: UUID
     """Unique ID of the message"""
 
-    content: str
+    content: bytes
     """Message content"""
 
     created_on: datetime

--- a/src/acoupi/components/messengers.py
+++ b/src/acoupi/components/messengers.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel, SecretStr, field_serializer
 from acoupi import data
 from acoupi.components import types
 from acoupi.devices import get_device_id
-from acoupi.system.exceptions import HealthCheckError
+from acoupi.system.exceptions import HealthCheckError, MessageSendError
 
 __all__ = [
     "MQTTMessenger",
@@ -108,7 +108,7 @@ class MQTTMessenger(types.Messenger):
             client_id=self.client_id,
             clean_session=False,
         )
-        
+
         self.client.username_pw_set(username, password)
 
         if logger is None:
@@ -117,7 +117,7 @@ class MQTTMessenger(types.Messenger):
         self.logger = logger
 
         if self.use_tls:
-            # Calling tls_set() without arguments uses the system's 
+            # Calling tls_set() without arguments uses the system's
             # default CA certificates, which works for HiveHQ
             self.logger.info("Using TLS Connection.")
             self.client.tls_set()
@@ -191,11 +191,8 @@ class MQTTMessenger(types.Messenger):
         mqtt_status = self.check_connection()
 
         if mqtt_status != MQTTErrorCode.MQTT_ERR_SUCCESS:
-            self.logger.warning(f"MQTT connection error: {mqtt_status}")
-            return data.Response(
-                message=message,
-                status=data.ResponseStatus.ERROR,
-                received_on=datetime.datetime.now(),
+            raise MessageSendError(
+                f"MQTT connection error: {MQTTErrorCode(mqtt_status).name}"
             )
 
         response = self.client.publish(
@@ -207,16 +204,15 @@ class MQTTMessenger(types.Messenger):
         try:
             response.wait_for_publish(timeout=5)
         except ValueError as e:
-            status = data.ResponseStatus.ERROR
-            logging.debug(f"Message not sent: {message.content}. Error: {e}")
+            raise MessageSendError(
+                f"MQTT publish failed for message {message.id}: {e}"
+            ) from e
         except RuntimeError as e:
-            status = data.ResponseStatus.FAILED
-            logging.debug(f"Message not sent: {message.content}. Error: {e}")
+            raise MessageSendError(
+                f"MQTT publish failed for message {message.id}: {e}"
+            ) from e
 
         if response.rc != MQTTErrorCode.MQTT_ERR_SUCCESS:
-            logging.debug(
-                f"Message not sent: {message.content}. Error: {response.rc}"
-            )
             status = data.ResponseStatus.ERROR
 
         received_on = datetime.datetime.now()
@@ -361,10 +357,13 @@ class HTTPMessenger(types.Messenger):
         status = data.ResponseStatus.SUCCESS
         response_content = None
 
-        message_content = message.content
-        content_json = json.loads(message_content)
-
         try:
+            message_content = message.content
+            if isinstance(message_content, bytes):
+                message_content = message_content.decode("utf-8")
+
+            content_json = json.loads(message_content)
+
             if self.content_type == "application/json":
                 response = requests.post(
                     self.base_url,
@@ -388,10 +387,18 @@ class HTTPMessenger(types.Messenger):
             if not response.ok:
                 status = data.ResponseStatus.ERROR
 
-        except ValueError:
-            status = data.ResponseStatus.ERROR
-        except RuntimeError:
-            status = data.ResponseStatus.FAILED
+        except (UnicodeDecodeError, ValueError) as error:
+            raise MessageSendError(
+                f"Invalid HTTP message payload for message {message.id}: {error}"
+            ) from error
+        except requests.exceptions.RequestException as error:
+            raise MessageSendError(
+                f"HTTP request failed for message {message.id}: {error}"
+            ) from error
+        except RuntimeError as error:
+            raise MessageSendError(
+                f"HTTP send failed for message {message.id}: {error}"
+            ) from error
 
         received_on = datetime.datetime.now()
 

--- a/src/acoupi/components/summariser.py
+++ b/src/acoupi/components/summariser.py
@@ -11,7 +11,7 @@ The message output by the Summarisers is then used by the Messenger to send the 
 to a remote server. Summarisers are implemented as classes that inherit from Summariser.
 Implemntation of the Summarisers should refer to the database, where the classifications
 probabilities are stored. The class should implement the build_summary method, which
-takes a datetime.datetime object and returns a message in JSON format.
+takes a datetime.datetime object and returns a message payload.
 """
 
 import datetime

--- a/src/acoupi/components/types.py
+++ b/src/acoupi/components/types.py
@@ -451,7 +451,8 @@ class Summariser(ABC):
         Returns
         -------
         data.Message
-            The summary as a data.Message object. The message should be in JSON format.
+            The summary as a data.Message object. Built-in summarisers emit
+            JSON text, but custom summarisers may emit raw bytes.
         """
 
 
@@ -486,6 +487,12 @@ class Messenger(ABC):
         -------
         data.Response
             A response containing the message, status, content, and received time.
+
+        Raises
+        ------
+        MessageSendError
+            Raised when the message could not be sent locally and no remote
+            response was received.
         """
 
 

--- a/src/acoupi/data.py
+++ b/src/acoupi/data.py
@@ -3,7 +3,7 @@
 import datetime
 from enum import IntEnum
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field, field_validator
@@ -297,8 +297,8 @@ class Message(BaseModel):
     id: UUID = Field(default_factory=uuid4)
     """The unique ID of the message."""
 
-    content: str
-    """The message to be sent. Usually a JSON string."""
+    content: Union[str, bytes]
+    """The message to be sent. Usually JSON text, but may be raw bytes."""
 
     created_on: datetime.datetime = Field(
         default_factory=datetime.datetime.now

--- a/src/acoupi/system/exceptions.py
+++ b/src/acoupi/system/exceptions.py
@@ -7,6 +7,8 @@ __all__ = [
     "DeploymentError",
     "HealthCheckError",
     "InvalidProgramError",
+    "MessageSendError",
+    "MessageStoreError",
     "ParameterError",
     "ProgramNotFoundError",
 ]
@@ -95,6 +97,32 @@ class DeploymentError(Exception):
 
     def __init__(self, message: str):
         """Initialise DeploymentError exception."""
+        self.message = message
+        super().__init__(message)
+
+    def __str__(self):
+        """Return the error message."""
+        return self.message
+
+
+class MessageSendError(Exception):
+    """Exception raised when a message cannot be sent locally."""
+
+    def __init__(self, message: str):
+        """Initialise MessageSendError exception."""
+        self.message = message
+        super().__init__(message)
+
+    def __str__(self):
+        """Return the error message."""
+        return self.message
+
+
+class MessageStoreError(Exception):
+    """Exception raised when the message store state is invalid."""
+
+    def __init__(self, message: str):
+        """Initialise MessageStoreError exception."""
         self.message = message
         super().__init__(message)
 

--- a/src/acoupi/tasks/messaging.py
+++ b/src/acoupi/tasks/messaging.py
@@ -16,6 +16,7 @@ import logging
 from typing import Callable, List, Optional
 
 from acoupi.components import types
+from acoupi.system.exceptions import MessageSendError
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -72,9 +73,22 @@ def generate_send_messages_task(
                 # break
 
             for messenger in messengers:
-                response = messenger.send_message(message)
+                try:
+                    response = messenger.send_message(message)
+                except MessageSendError as error:
+                    logger.error(
+                        "Message send failed for message %s via %s: %s",
+                        message.id,
+                        messenger.__class__.__name__,
+                        error,
+                    )
+                    continue
+
                 logger.info(
-                    f"Message Sent - Response Status: {response.status}"
+                    "Message sent for message %s via %s - Response Status: %s",
+                    message.id,
+                    messenger.__class__.__name__,
+                    response.status,
                 )
                 message_store.store_response(response)
 

--- a/tests/test_components/test_messengers.py
+++ b/tests/test_components/test_messengers.py
@@ -6,11 +6,12 @@ from unittest import mock
 
 import pytest
 import pytest_httpserver
+import requests
 from paho.mqtt.enums import MQTTErrorCode
 
 from acoupi import data
 from acoupi.components import messengers
-from acoupi.system.exceptions import HealthCheckError
+from acoupi.system.exceptions import HealthCheckError, MessageSendError
 
 
 def test_http_messenger():
@@ -72,6 +73,113 @@ def test_http_messenger_with_params():
             },
             timeout=5,
         )
+
+
+def test_http_messenger_accepts_utf8_json_bytes():
+    """Test the HTTPMessenger accepts JSON payloads encoded as bytes."""
+    with mock.patch("requests.post") as mock_post:
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.text = "OK"
+
+        messenger = messengers.HTTPMessenger(
+            base_url="http://localhost:5000",
+            timeout=5,
+        )
+
+        message = data.Message(content=b'"Hello, world!"')
+
+        response = messenger.send_message(message)
+
+        assert response.status == data.ResponseStatus.SUCCESS
+        assert response.content == "OK"
+
+        mock_post.assert_called_once_with(
+            "http://localhost:5000",
+            json="Hello, world!",
+            params={},
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            timeout=5,
+        )
+
+
+def test_http_messenger_rejects_non_utf8_bytes():
+    """Test the HTTPMessenger rejects bytes that are not UTF-8."""
+    with mock.patch("requests.post") as mock_post:
+        messenger = messengers.HTTPMessenger(
+            base_url="http://localhost:5000",
+            timeout=5,
+        )
+
+        message = data.Message(content=b"\x80\x81\x82")
+
+        with pytest.raises(
+            MessageSendError, match="Invalid HTTP message payload"
+        ):
+            messenger.send_message(message)
+
+        mock_post.assert_not_called()
+
+
+def test_http_messenger_rejects_invalid_json_bytes():
+    """Test the HTTPMessenger rejects UTF-8 bytes that are not JSON."""
+    with mock.patch("requests.post") as mock_post:
+        messenger = messengers.HTTPMessenger(
+            base_url="http://localhost:5000",
+            timeout=5,
+        )
+
+        message = data.Message(content=b"not json")
+
+        with pytest.raises(
+            MessageSendError, match="Invalid HTTP message payload"
+        ):
+            messenger.send_message(message)
+
+        mock_post.assert_not_called()
+
+
+def test_http_messenger_raises_on_request_exception():
+    """Test the HTTPMessenger raises on local request failures."""
+    with mock.patch("requests.post") as mock_post:
+        mock_post.side_effect = requests.exceptions.ConnectionError("boom")
+        messenger = messengers.HTTPMessenger(
+            base_url="http://localhost:5000",
+            timeout=5,
+        )
+
+        message = data.Message(content='"Hello, world!"')
+
+        with pytest.raises(MessageSendError, match="HTTP request failed"):
+            messenger.send_message(message)
+
+
+def test_mqtt_messenger_raises_when_connection_fails():
+    """Test the MQTTMessenger raises on local connection failures."""
+    config = {
+        "is_connected.return_value": False,
+        "host": None,
+        "connect.return_value": MQTTErrorCode.MQTT_ERR_NO_CONN,
+    }
+
+    with mock.patch(
+        "paho.mqtt.client.Client",
+        spec=True,
+        **config,
+    ):
+        messenger = messengers.MQTTMessenger(
+            host="localhost",
+            port=1883,
+            username="test",
+            topic="acoupi",
+        )
+
+        message = data.Message(content='"Hello, world!"')
+
+        with pytest.raises(MessageSendError, match="MQTT connection error"):
+            messenger.send_message(message)
 
 
 def test_http_messeger_with_custom_headers():
@@ -308,6 +416,72 @@ def test_mqtt_messenger_can_send_simple_message():
         # Assert
         assert response.status == data.ResponseStatus.SUCCESS
         assert response.content == "MQTT_ERR_SUCCESS"
+
+        mock_client.return_value.publish.assert_called_once_with(
+            topic="acoupi",
+            payload='"Hello, world!"',
+        )
+
+
+def test_mqtt_messenger_can_send_bytes_message():
+    """Test the MQTTMessenger can send a bytes payload."""
+    mock_response = mock.MagicMock()
+    mock_response.rc = 0
+    config = {
+        "is_connected.return_value": True,
+        "publish.return_value": mock_response,
+    }
+
+    with mock.patch(
+        "paho.mqtt.client.Client",
+        spec=True,
+        **config,
+    ) as mock_client:
+        messenger = messengers.MQTTMessenger(
+            host="localhost",
+            port=1883,
+            username="test",
+            topic="acoupi",
+        )
+        message = data.Message(content=b"\x01\x02payload")
+
+        response = messenger.send_message(message)
+
+        assert response.status == data.ResponseStatus.SUCCESS
+        assert response.content == "MQTT_ERR_SUCCESS"
+
+        mock_client.return_value.publish.assert_called_once_with(
+            topic="acoupi",
+            payload=b"\x01\x02payload",
+        )
+
+
+def test_mqtt_messenger_returns_error_response_for_publish_rc_error():
+    """Test the MQTTMessenger returns a response for broker publish errors."""
+    mock_response = mock.MagicMock()
+    mock_response.rc = MQTTErrorCode.MQTT_ERR_QUEUE_SIZE
+    config = {
+        "is_connected.return_value": True,
+        "publish.return_value": mock_response,
+    }
+
+    with mock.patch(
+        "paho.mqtt.client.Client",
+        spec=True,
+        **config,
+    ) as mock_client:
+        messenger = messengers.MQTTMessenger(
+            host="localhost",
+            port=1883,
+            username="test",
+            topic="acoupi",
+        )
+        message = data.Message(content='"Hello, world!"')
+
+        response = messenger.send_message(message)
+
+        assert response.status == data.ResponseStatus.ERROR
+        assert response.content == "MQTT_ERR_QUEUE_SIZE"
 
         mock_client.return_value.publish.assert_called_once_with(
             topic="acoupi",

--- a/tests/test_components/test_sqlite_message_store.py
+++ b/tests/test_components/test_sqlite_message_store.py
@@ -7,6 +7,7 @@ from typing import Generator
 import pytest
 
 from acoupi import components, data
+from acoupi.system.exceptions import MessageStoreError
 
 
 @pytest.fixture(scope="function")
@@ -75,7 +76,24 @@ def test_store_message(
         cursor = conn.cursor()
         cursor.execute("SELECT * FROM message;")
         row = cursor.fetchone()
-        assert row[1] == "test message"
+        assert row[1] == b"test message"
+        assert row[0] == message.id.bytes
+
+
+def test_store_message_bytes(
+    sqlite_message_store: components.SqliteMessageStore,
+):
+    """Test storing a byte message."""
+    message = data.Message(content=b"\x01\x02test")
+
+    sqlite_message_store.store_message(message)
+
+    db_path = sqlite_message_store.db_path
+    with sqlite3.connect(str(db_path)) as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM message;")
+        row = cursor.fetchone()
+        assert row[1] == b"\x01\x02test"
         assert row[0] == message.id.bytes
 
 
@@ -92,6 +110,7 @@ def test_store_response(
     )
 
     # Act
+    sqlite_message_store.store_message(message)
     sqlite_message_store.store_response(response)
 
     # Assert
@@ -105,6 +124,21 @@ def test_store_response(
         assert row[2] == message.id.bytes
         assert row[3] == data.ResponseStatus.SUCCESS.value
         assert row[4] is not None
+
+
+def test_store_response_raises_for_missing_message(
+    sqlite_message_store: components.SqliteMessageStore,
+):
+    """Test storing a response fails if the message is not stored."""
+    message = data.Message(content=b"\x01\x02payload")
+    response = data.Response(
+        content="test response",
+        status=data.ResponseStatus.SUCCESS,
+        message=message,
+    )
+
+    with pytest.raises(MessageStoreError, match="unknown message"):
+        sqlite_message_store.store_response(response)
 
 
 def test_get_unsent_messages(
@@ -136,3 +170,7 @@ def test_get_unsent_messages(
 
     # Assert
     assert len(unsent_messages) == 2
+    assert {message.content for message in unsent_messages} == {
+        b"test message 2",
+        b"test message 3",
+    }


### PR DESCRIPTION
## Summary
- allow `data.Message.content` to be `str` or `bytes`
- store message payloads in SQLite as bytes
- keep HTTP messaging JSON-based, with UTF-8 decoding for byte payloads
- separate local send failures from remote response errors
- make storing a response for an unknown message raise an error

## Details
- `Message.content` now supports raw bytes for binary transports such as LoRa
- string payloads are stored as UTF-8 bytes in the message store
- unsent messages are read back as bytes
- HTTP messenger raises `MessageSendError` for local payload/request failures
- MQTT messenger raises `MessageSendError` for local send failures
- MQTT publish response codes are returned as normal error responses
- `store_response()` now raises `MessageStoreError` if the message was not stored first

## Breaking change
- the message store schema now persists message payloads as bytes instead of text
- `get_unsent_messages()` now returns messages with byte payloads
- `store_response()` no longer creates missing messages automatically

## Upgrade note
- existing `messages.db` files are not migrated automatically
- if unsent messages in an old deployment need to be preserved, archive the old `messages.db` first
- otherwise, remove the old `messages.db` and let acoupi create a new one

## Tests
- added coverage for byte payload storage
- added coverage for HTTP byte payload handling
- added coverage for local send failures vs remote response errors
- added coverage for rejecting responses for unknown messages