### PR TITLE
Add templated recording filenames to DateFileManager

### DIFF
--- a/src/acoupi/components/saving_managers.py
+++ b/src/acoupi/components/saving_managers.py
@@ -20,6 +20,7 @@ The SavingManagers are optional and can be ingored if the no recordings are save
 
 import logging
 import os
+import string
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import List, Optional
@@ -28,6 +29,7 @@ from celery.utils.log import get_task_logger
 
 from acoupi import data
 from acoupi.components import types
+from acoupi.devices import get_device_info
 
 __all__ = [
     "SaveRecordingManager",
@@ -265,21 +267,150 @@ class BaseFileManager(types.RecordingSavingManager, ABC):
         return full_path
 
 
-class DateFileManager(BaseFileManager):
-    """FileManager that uses the date to organise the recordings.
+_SANITIZE_TABLE = str.maketrans({char: "_" for char in '<>:"/\\|?*'})
 
-    The recordings are organised in directories of the form
 
-    YYYY/MM/DD/
+def sanitize_filename(filename: str) -> str:
+    """Replace characters that are unsafe in filenames."""
+    return filename.translate(_SANITIZE_TABLE)
 
-    where YYYY is the year, MM is the month and DD is the day. The files
-    are named using the time of the recording and its ID. The format is
 
-    HHMMSS_ID.wav
+class FilenameFormatter(string.Formatter):
+    """Format filename templates while treating ``None`` as an empty string.
 
-    All the files are stored in a single directory that is specified in
-    the constructor.
+    This keeps optional context fields, such as deployment coordinates or the
+    device id, from raising formatting errors when they are missing.
     """
+
+    def get_value(self, key, args, kwargs):
+        value = super().get_value(key, args, kwargs)
+        if value is None:
+            return ""
+        return value
+
+    def format_field(self, value, format_spec):
+        if value is None:
+            value = ""
+        return super().format_field(value, format_spec)
+
+
+class DateFileManager(BaseFileManager):
+    """Save recordings into date-based folders.
+
+    Recordings are stored in a directory structure based on the recording
+    date:
+
+    ``YYYY/MM/DD/``
+
+    By default, each filename includes the recording date, time, and the
+    recording ID:
+
+    ``YYYYMMDD_HHMMSS_<recording-id>.wav``
+
+    Examples
+    --------
+    Use the default filename pattern:
+
+    >>> manager = DateFileManager(Path("recordings"))
+    >>> recording = data.Recording(
+    ...     path=Path("tmp.wav"),
+    ...     duration=1.0,
+    ...     samplerate=48000,
+    ...     deployment=data.Deployment(name="site-a"),
+    ... )
+    >>> relative_path = manager.get_file_path(recording)
+    >>> relative_path.parts[:3] == (
+    ...     str(recording.created_on.year),
+    ...     str(recording.created_on.month),
+    ...     str(recording.created_on.day),
+    ... )
+    True
+
+    Notes
+    -----
+    The filename can be customized by providing a different
+    ``filename_template``. The template uses Python's standard format-string
+    syntax and can reference ``recording``, ``deployment``, and ``device``.
+    Use ``recording.created_on`` with datetime format specifiers when you need
+    year, month, day, or time components in the filename.
+
+    Build a more descriptive filename from deployment and recording fields:
+
+    >>> manager = DateFileManager(
+    ...     Path("recordings"),
+    ...     filename_template=(
+    ...         "{deployment.name}_{recording.created_on:%Y%m%d_%H%M%S}"
+    ...         "_{recording.samplerate}Hz.wav"
+    ...     ),
+    ... )
+
+    Include the runtime device id when available:
+
+    >>> manager = DateFileManager(
+    ...     Path("recordings"),
+    ...     filename_template=(
+    ...         "{deployment.name}_{device.id}_"
+    ...         "{recording.created_on:%H%M%S}.wav"
+    ...     ),
+    ... )
+
+    If you need a different directory layout altogether, use another file
+    manager or subclass ``BaseFileManager``.
+    """
+
+    filename_template: str
+
+    def __init__(
+        self,
+        directory: Path,
+        filename_template: str = (
+            "{recording.created_on:%Y%m%d_%H%M%S}_{recording.id}.wav"
+        ),
+        logger: Optional[logging.Logger] = None,
+    ):
+        """Create a date-based file manager.
+
+        Parameters
+        ----------
+        directory:
+            Root directory where recordings are stored.
+        filename_template:
+            Format string used to build the filename within the date-based
+            directory. The template can reference ``recording``, ``deployment``
+            and ``device`` fields, for example
+            ``"{deployment.name}_{recording.created_on:%Y%m%d_%H%M%S}.wav"``.
+        logger:
+            Optional logger used by the manager.
+        """
+        super().__init__(directory=directory, logger=logger)
+        self.filename_template = filename_template
+
+    def _render_filename(self, recording: data.Recording) -> str:
+        """Render and sanitize the filename for a recording.
+
+        Raises
+        ------
+        ValueError
+            If the template references an unknown field or contains an invalid
+            format specification.
+        """
+        formatter = FilenameFormatter()
+
+        device = get_device_info()
+
+        try:
+            filename = formatter.format(
+                self.filename_template,
+                recording=recording,
+                deployment=recording.deployment,
+                device=device,
+            )
+        except (AttributeError, KeyError, ValueError) as error:
+            raise ValueError(
+                f"Invalid filename template: {self.filename_template}"
+            ) from error
+
+        return sanitize_filename(filename)
 
     def get_file_path(self, recording: data.Recording) -> Path:
         """Get the path where the file of a recording should be stored.
@@ -292,13 +423,17 @@ class DateFileManager(BaseFileManager):
         Returns
         -------
             Path of the file.
+
+        Notes
+        -----
+        The returned path is relative to ``self.directory`` and always follows
+        the ``YYYY/MM/DD/<filename>`` structure.
         """
         date = recording.created_on
         directory = (
             Path(str(date.year)) / Path(str(date.month)) / Path(str(date.day))
         )
-        time = recording.created_on.strftime("%H%M%S")
-        return directory / Path(f"{time}_{recording.id}.wav")
+        return directory / Path(self._render_filename(recording))
 
 
 class IDFileManager(BaseFileManager):

--- a/src/acoupi/data.py
+++ b/src/acoupi/data.py
@@ -32,6 +32,17 @@ class TimeInterval(BaseModel):
     """End time of the interval."""
 
 
+class DeviceInfo(BaseModel):
+    """Runtime information about the current device.
+
+    This object is intentionally small and currently only exposes the device
+    identifier used in filename templates and heartbeat-style messages.
+    """
+
+    id: str
+    """Unique identifier for the current device, if available."""
+
+
 class Deployment(BaseModel):
     """A Deployment captures information about the device deployment.
 

--- a/src/acoupi/devices/__init__.py
+++ b/src/acoupi/devices/__init__.py
@@ -7,7 +7,9 @@ like serial numbers and hostnames.
 """
 
 import uuid
+from functools import cache
 
+from acoupi.data import DeviceInfo
 from acoupi.devices.rpi import get_rpi_host_name, get_rpi_serial_number, is_rpi
 
 
@@ -36,9 +38,26 @@ def get_device_id() -> str:
     return str(uuid.getnode())
 
 
+@cache
+def get_device_info() -> DeviceInfo:
+    """Get cached runtime information about the current device.
+
+    Returns
+    -------
+    DeviceInfo
+        Device information for the current process. If the device identifier
+        cannot be resolved, the returned object contains an empty ``id``.
+    """
+    try:
+        return DeviceInfo(id=get_device_id())
+    except Exception:
+        return DeviceInfo(id="")
+
+
 __all__ = [
     "get_rpi_serial_number",
     "get_rpi_host_name",
     "get_device_id",
+    "get_device_info",
     "is_rpi",
 ]

--- a/src/acoupi/programs/templates/basic.py
+++ b/src/acoupi/programs/templates/basic.py
@@ -323,8 +323,12 @@ class BasicProgram(AcoupiProgram[ProgramConfig]):
         allowing the next manager in the list to be used.
 
         By default, this method returns a list containing a single
-        `DateFileManager`, which saves recordings in a structured folder
-        hierarchy based on the recording date.
+        `DateFileManager`, which stores recordings under `YYYY/MM/DD/` and
+        uses a filename template that includes the recording date, time, and
+        ID.
+
+        Override this method if you want to provide a different saving manager
+        or a customised `DateFileManager(filename_template=...)`.
 
         Returns
         -------

--- a/tests/test_components/test_file_managers.py
+++ b/tests/test_components/test_file_managers.py
@@ -2,10 +2,12 @@
 
 import datetime
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from acoupi import components, data
+from acoupi.components import saving_managers
 
 
 def test_save_recording_manager_fails_if_recording_has_no_path(
@@ -140,8 +142,99 @@ def test_date_file_manager_save_recording(
     # Assert
     assert directory.exists()
     assert file_path == (
-        directory / "2023" / "4" / "15" / f"180930_{recording.id}.wav"
+        directory / "2023" / "4" / "15" / f"20230415_180930_{recording.id}.wav"
     )
+
+
+def test_date_file_manager_supports_custom_filename_template(
+    tmp_path: Path,
+    deployment: data.Deployment,
+):
+    path = tmp_path / "test.wav"
+    directory = tmp_path / "recordings"
+    recording = data.Recording(
+        path=path,
+        duration=1.5,
+        samplerate=48000,
+        audio_channels=2,
+        created_on=datetime.datetime(2023, 4, 15, 18, 9, 30),
+        deployment=data.Deployment(
+            name="My Site/1",
+            latitude=51.5,
+            longitude=-0.1,
+            started_on=deployment.started_on,
+        ),
+    )
+    path.touch()
+
+    with patch(
+        "acoupi.components.saving_managers.get_device_info",
+        return_value=data.DeviceInfo(id=""),
+    ):
+        file_manager = components.DateFileManager(
+            directory,
+            filename_template=(
+                "{deployment.name}_{device.id}_{recording.created_on:%H%M}.wav"
+            ),
+        )
+        file_path = file_manager.save_recording(recording)
+
+    assert file_path == (
+        directory / "2023" / "4" / "15" / "My Site_1__1809.wav"
+    )
+
+
+def test_date_file_manager_uses_empty_device_id_when_unavailable(
+    tmp_path: Path,
+):
+    path = tmp_path / "test.wav"
+    directory = tmp_path / "recordings"
+    recording = data.Recording(
+        path=path,
+        duration=1,
+        samplerate=48000,
+        created_on=datetime.datetime(2023, 4, 15, 18, 9, 30),
+        deployment=data.Deployment(name="site-a"),
+    )
+    path.touch()
+
+    with patch(
+        "acoupi.devices.get_device_id",
+        side_effect=RuntimeError("device unavailable"),
+    ):
+        from acoupi.devices import get_device_info
+
+        get_device_info.cache_clear()
+        file_path = components.DateFileManager(
+            directory,
+            filename_template="{device.id}_{recording.created_on:%H%M}.wav",
+        ).save_recording(recording)
+
+    assert file_path == directory / "2023" / "4" / "15" / "_1809.wav"
+
+
+def test_date_file_manager_fails_with_invalid_filename_template(
+    tmp_path: Path,
+    deployment: data.Deployment,
+):
+    path = tmp_path / "test.wav"
+    directory = tmp_path / "recordings"
+    recording = data.Recording(
+        path=path,
+        duration=1,
+        samplerate=8000,
+        created_on=datetime.datetime(2023, 4, 15, 18, 9, 30),
+        deployment=deployment,
+    )
+    path.touch()
+
+    file_manager = components.DateFileManager(
+        directory,
+        filename_template="{recording.hour:02d}.wav",
+    )
+
+    with pytest.raises(ValueError, match="Invalid filename template"):
+        file_manager.save_recording(recording)
 
 
 def test_date_file_manager_fails_if_recording_has_no_path(

--- a/tests/test_components/test_saving_managers.py
+++ b/tests/test_components/test_saving_managers.py
@@ -305,4 +305,6 @@ def test_date_file_manager_save_recording(
 
     # Assert
     assert tmp_audio_dirpath.exists()
-    assert file_path == Path("2024") / "8" / "1" / f"203000_{recording.id}.wav"
+    assert file_path == (
+        Path("2024") / "8" / "1" / f"20240801_203000_{recording.id}.wav"
+    )

--- a/tests/test_programs/test_callbacks.py
+++ b/tests/test_programs/test_callbacks.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel
 from acoupi.programs.core.base import AcoupiProgram
 from acoupi.programs.core.workers import AcoupiWorker, WorkerConfig
 
-
 WaitForCondition = Callable[..., None]
 
 
@@ -66,7 +65,8 @@ def test_does_run_callbacks(
     output = program.tasks["task_1"].delay()
     output.get(timeout=3)
 
-    wait_for_condition(path.exists)
+    wait_for_condition(path.exists, timeout=3)
+    wait_for_condition(path.read_text() == message, timeout=3)
 
     assert path.exists()
     assert path.read_text() == message

--- a/tests/test_programs/test_callbacks.py
+++ b/tests/test_programs/test_callbacks.py
@@ -66,7 +66,7 @@ def test_does_run_callbacks(
     output.get(timeout=3)
 
     wait_for_condition(path.exists, timeout=3)
-    wait_for_condition(path.read_text() == message, timeout=3)
+    wait_for_condition(lambda: path.read_text() == message, timeout=3)
 
     assert path.exists()
     assert path.read_text() == message
@@ -130,6 +130,7 @@ def test_does_run_callbacks_in_other_queues(
     output.get(timeout=3)
 
     wait_for_condition(path.exists)
+    wait_for_condition(lambda: path.read_text() == message, timeout=3)
 
     assert path.exists()
     assert path.read_text() == message


### PR DESCRIPTION
## Summary

This PR updates `DateFileManager` so saved recording filenames are more descriptive by default and can also be customized.

By default, recordings are still stored under `YYYY/MM/DD/`, but filenames now include the date as well as the time:

`YYYYMMDD_HHMMSS_<recording-id>.wav`

This addresses #92 by making recordings easier to sort and manage even after they are moved out of their original directory structure.

## Changes

- update the default `DateFileManager` filename format to include the date
- add `filename_template` support to `DateFileManager`
- allow templates to use `recording`, `deployment`, and `device` fields
- add `DeviceInfo` and `get_device_info()` for filename context
- return an empty device id if device information cannot be read
- expand `DateFileManager` docstrings and usage examples
- add tests for:
  - the new default filename format
  - custom filename templates
  - missing device id fallback
  - invalid filename templates

## Testing

- `pytest tests/test_components/test_file_managers.py tests/test_components/test_saving_managers.py`
