### PR TITLE
Add time expansion support to recordings

### DIFF
--- a/src/acoupi/components/audio_recorder.py
+++ b/src/acoupi/components/audio_recorder.py
@@ -244,7 +244,7 @@ class MicrophoneConfig(BaseModel):
     device_name: str
     samplerate: int = 48_000
     audio_channels: int = 1
-    time_expansion_factor: float = Field(default=1, gt=0)
+    time_expansion: float = Field(default=1, gt=0)
 
     @classmethod
     def setup(
@@ -323,10 +323,19 @@ def parse_microphone_config(
             prefix=prefix,
         )
 
+        time_expansion = parse_field_from_args(
+            "time_expansion",
+            MicrophoneConfig.model_fields["time_expansion"],
+            args,
+            prompt=False,
+            prefix=prefix,
+        )
+
         return MicrophoneConfig(
             device_name=device.name,
             samplerate=int(samplerate),  # type: ignore
             audio_channels=channels or 1,  # type: ignore
+            time_expansion=time_expansion,  # type: ignore
         )
 
     click.secho("Available audio devices:\n", fg="green", bold=True)
@@ -427,11 +436,11 @@ def parse_microphone_config(
                     fg="red",
                 )
 
-    time_expansion_factor = click.prompt(
+    time_expansion = click.prompt(
         "Adjust the playback speed/duration metadata for downstream analysis.\n"
         "Example: Enter 10.0 if you recorded at 480kHz but need to process at 48kHz.\n"
         "Enter the time expansion factor (default: 1.0). \n",
-        type=click.FloatRange(min=0.0, clamp=False),
+        type=click.FloatRange(min=0.0, clamp=False, min_open=True),
         default=1.0,
     )
 
@@ -439,5 +448,5 @@ def parse_microphone_config(
         device_name=selected_device.name,
         samplerate=samplerate,
         audio_channels=channels,
-        time_expansion_factor=time_expansion_factor,
+        time_expansion=time_expansion,
     )

--- a/src/acoupi/components/audio_recorder.py
+++ b/src/acoupi/components/audio_recorder.py
@@ -23,7 +23,7 @@ from typing import List, Optional
 import click
 import pyaudio
 from celery.utils.log import get_task_logger
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from acoupi import data
 from acoupi.components.types import AudioRecorder
@@ -87,6 +87,9 @@ class PyAudioRecorder(AudioRecorder):
         self.audio_dir = audio_dir
         self.sample_width = pyaudio.get_sample_size(pyaudio.paInt16)
         self.time_expansion = time_expansion
+
+        if self.time_expansion <= 0:
+            raise ValueError("time_expansion must be greater than 0")
 
         if logger is None:
             logger = get_task_logger(__name__)
@@ -241,7 +244,7 @@ class MicrophoneConfig(BaseModel):
     device_name: str
     samplerate: int = 48_000
     audio_channels: int = 1
-    time_expansion_factor: float = 1
+    time_expansion_factor: float = Field(default=1, gt=0)
 
     @classmethod
     def setup(

--- a/src/acoupi/components/audio_recorder.py
+++ b/src/acoupi/components/audio_recorder.py
@@ -59,6 +59,9 @@ class PyAudioRecorder(AudioRecorder):
     audio_dir: Path
     """The directory where to store the created recordings."""
 
+    time_expansion: float
+    """The time expansion factor for the recording."""
+
     def __init__(
         self,
         duration: float,
@@ -68,6 +71,7 @@ class PyAudioRecorder(AudioRecorder):
         chunksize: int = 2048,
         audio_dir: Path = TMP_PATH,
         logger=None,
+        time_expansion: float = 1,
     ) -> None:
         """Initialise the AudioRecorder with the audio parameters."""
         # Audio Duration
@@ -82,6 +86,7 @@ class PyAudioRecorder(AudioRecorder):
         self.chunksize = chunksize
         self.audio_dir = audio_dir
         self.sample_width = pyaudio.get_sample_size(pyaudio.paInt16)
+        self.time_expansion = time_expansion
 
         if logger is None:
             logger = get_task_logger(__name__)
@@ -98,12 +103,14 @@ class PyAudioRecorder(AudioRecorder):
         temp_path = self.audio_dir / f"{now.strftime('%Y%m%d_%H%M%S')}.wav"
         frames = self.get_recording_data(duration=self.duration)
         self.save_recording(frames, temp_path)
+
         return data.Recording(
             path=temp_path,
             created_on=now,
             duration=self.duration,
             samplerate=self.samplerate,
             audio_channels=self.audio_channels,
+            time_expansion=self.time_expansion,
             chunksize=self.chunksize,
             deployment=deployment,
         )
@@ -162,12 +169,15 @@ class PyAudioRecorder(AudioRecorder):
 
         return data
 
+    def get_expanded_samplerate(self):
+        return int(self.samplerate / self.time_expansion)
+
     def save_recording(self, data: bytes, path: Path) -> None:
         """Save the recording to a file."""
         with wave.open(str(path), "wb") as temp_audio_file:
             temp_audio_file.setnchannels(self.audio_channels)
             temp_audio_file.setsampwidth(self.sample_width)
-            temp_audio_file.setframerate(self.samplerate)
+            temp_audio_file.setframerate(self.get_expanded_samplerate())
             temp_audio_file.writeframes(data)
 
     def get_input_device(self, p: pyaudio.PyAudio):
@@ -231,6 +241,7 @@ class MicrophoneConfig(BaseModel):
     device_name: str
     samplerate: int = 48_000
     audio_channels: int = 1
+    time_expansion_factor: float = 1
 
     @classmethod
     def setup(
@@ -413,8 +424,17 @@ def parse_microphone_config(
                     fg="red",
                 )
 
+    time_expansion_factor = click.prompt(
+        "Adjust the playback speed/duration metadata for downstream analysis.\n"
+        "Example: Enter 10.0 if you recorded at 480kHz but need to process at 48kHz.\n"
+        "Enter the time expansion factor (default: 1.0). \n",
+        type=click.FloatRange(min=0.0, clamp=False),
+        default=1.0,
+    )
+
     return MicrophoneConfig(
         device_name=selected_device.name,
         samplerate=samplerate,
         audio_channels=channels,
+        time_expansion_factor=time_expansion_factor,
     )

--- a/src/acoupi/components/messengers.py
+++ b/src/acoupi/components/messengers.py
@@ -245,6 +245,10 @@ class MQTTMessenger(types.Messenger):
             raise HealthCheckError(
                 "Health check failed: Unable to resolve the MQTT broker host."
             ) from err
+        except socket.timeout as err:
+            raise HealthCheckError(
+                "Health check failed: Timeout connecting to the MQTT broker."
+            ) from err
 
         if mqtt_status != MQTTErrorCode.MQTT_ERR_SUCCESS:
             error_name = MQTTErrorCode(mqtt_status).name

--- a/src/acoupi/data.py
+++ b/src/acoupi/data.py
@@ -115,7 +115,7 @@ class Recording(BaseModel):
     chunksize: Optional[int] = Field(default=4096, repr=False)
     """The chunksize of the audio file in bytes. Defaults to 4096."""
 
-    time_expansion: float = Field(default=1, repr=False)
+    time_expansion: float = Field(default=1, repr=False, gt=0)
     """Factor by which the recording's time scale is multiplied.
 
     Values > 1.0 indicate time expansion (slowing down playback), while values

--- a/src/acoupi/data.py
+++ b/src/acoupi/data.py
@@ -115,6 +115,13 @@ class Recording(BaseModel):
     chunksize: Optional[int] = Field(default=4096, repr=False)
     """The chunksize of the audio file in bytes. Defaults to 4096."""
 
+    time_expansion: float = Field(default=1, repr=False)
+    """Factor by which the recording's time scale is multiplied.
+
+    Values > 1.0 indicate time expansion (slowing down playback), while values
+    between 0.0 and 1.0 indicate time compression (speeding up playback).
+    """
+
     id: UUID = Field(default_factory=uuid4, repr=True)
     """The unique ID of the recording"""
 

--- a/src/acoupi/tasks/recording.py
+++ b/src/acoupi/tasks/recording.py
@@ -123,6 +123,10 @@ def add_guano_metadata(recording: data.Recording) -> None:
     g["Firmware Version"] = version("acoupi")
     g["Make"] = "acoupi"
     g["Serial"] = get_rpi_serial_number()
+    g["Samplerate"] = recording.samplerate
+
+    if recording.time_expansion != 1:
+        g["TE"] = recording.time_expansion
 
     if (
         recording.deployment.longitude is not None

--- a/tests/test_components/test_audio_recording.py
+++ b/tests/test_components/test_audio_recording.py
@@ -182,6 +182,10 @@ def test_recording_duration_is_as_requested(
         )
 
 
+@pytest.mark.skipif(
+    not has_input_audio_device(),
+    reason="No audio device found.",
+)
 def test_can_record_with_time_expansion(
     tmp_path: Path, deployment: data.Deployment
 ):
@@ -211,6 +215,10 @@ def test_can_record_with_time_expansion(
         )
 
 
+@pytest.mark.skipif(
+    not has_input_audio_device(),
+    reason="No audio device found.",
+)
 def test_time_expansion_is_saved_in_guano_metadata(
     tmp_path: Path, deployment: data.Deployment, mocker
 ):
@@ -237,3 +245,4 @@ def test_time_expansion_is_saved_in_guano_metadata(
     assert recording.path is not None
     g = guano.GuanoFile(str(recording.path))
     assert g["TE"] == str(0.1)
+    assert g["Samplerate"] == samplerate

--- a/tests/test_components/test_audio_recording.py
+++ b/tests/test_components/test_audio_recording.py
@@ -4,11 +4,13 @@ import math
 import wave
 from pathlib import Path
 
+import guano
 import pytest
 
 from acoupi import components, data
 from acoupi.devices.audio import get_default_microphone, has_input_audio_device
 from acoupi.system.exceptions import HealthCheckError
+from acoupi.tasks.recording import add_guano_metadata
 
 
 @pytest.mark.skipif(
@@ -44,7 +46,7 @@ def test_audio_recording(deployment: data.Deployment, tmp_path: Path):
     reason="No audio device found.",
 )
 def test_check_is_succesful(tmp_path: Path):
-    """Test check_is_succesful"""
+    """Test check_is_succesful."""
     audio_channels, samplerate, device_name = get_default_microphone()
     recorder = components.PyAudioRecorder(
         duration=0.1,
@@ -178,3 +180,60 @@ def test_recording_duration_is_as_requested(
             wf.getnframes() / samplerate,
             abs_tol=0.01,
         )
+
+
+def test_can_record_with_time_expansion(
+    tmp_path: Path, deployment: data.Deployment
+):
+    _, samplerate, device_name = get_default_microphone()
+    recorder = components.PyAudioRecorder(
+        duration=1,
+        samplerate=samplerate,
+        audio_channels=1,
+        device_name=device_name,
+        chunksize=8192,
+        audio_dir=tmp_path,
+        time_expansion=0.1,
+    )
+
+    recording = recorder.record(deployment=deployment)
+
+    # The recording object has the original samplerate
+    assert recording.samplerate == samplerate
+    assert recording.time_expansion == 0.1
+
+    with wave.open(str(recording.path)) as wf:
+        stored_samplerate = wf.getframerate()
+        assert math.isclose(
+            stored_samplerate,
+            recorder.get_expanded_samplerate(),
+            abs_tol=0.01,
+        )
+
+
+def test_time_expansion_is_saved_in_guano_metadata(
+    tmp_path: Path, deployment: data.Deployment, mocker
+):
+    mocker.patch(
+        "acoupi.tasks.recording.get_rpi_serial_number",
+        return_value="1234567890ABCDEF",
+    )
+
+    _, samplerate, device_name = get_default_microphone()
+    recorder = components.PyAudioRecorder(
+        duration=1,
+        samplerate=samplerate,
+        audio_channels=1,
+        device_name=device_name,
+        chunksize=8192,
+        audio_dir=tmp_path,
+        time_expansion=0.1,
+    )
+
+    recording = recorder.record(deployment=deployment)
+
+    add_guano_metadata(recording)
+
+    assert recording.path is not None
+    g = guano.GuanoFile(str(recording.path))
+    assert g["TE"] == str(0.1)


### PR DESCRIPTION
## Summary

This PR adds time expansion support to recordings so audio can be captured at one sample rate while being saved with adjusted playback timing for downstream analysis.

## What changed
- Added time_expansion to recording metadata
- Added time_expansion support to PyAudioRecorder
- Save WAV files using an adjusted sample rate derived from samplerate / time_expansion
- Preserve the original recording sample rate in GUANO metadata as Samplerate
- Add GUANO TE metadata when time expansion is not 1
- Added config support for time_expansion in both interactive and non-interactive microphone setup
- Added validation to reject non-positive time expansion values
- Improved MQTT health checks by surfacing socket timeout failures explicitly

## Why

This supports workflows where audio is recorded at a high rate but should be analyzed or played back at a lower effective rate.

Example:

- record at 480000 Hz
- set `time_expansion=10`
- save the WAV header at 48000 Hz
- keep the original recording rate in metadata for downstream consumers

## Behavior
- `Recording.samplerate` continues to store the original recording sample rate
- WAV header sample rate reflects the playback/analyzed rate after time expansion
- `time_expansion > 1` slows playback / expands time
- `0 < time_expansion < 1` speeds playback / compresses time
- Default behavior remains unchanged with `time_expansion=1`