### PR TITLE
Add enum parser and move mqtt transport to enum field

### DIFF
--- a/src/acoupi/components/messengers.py
+++ b/src/acoupi/components/messengers.py
@@ -17,6 +17,7 @@ import datetime
 import json
 import logging
 import socket
+from enum import Enum
 from typing import Literal, Optional
 
 import paho.mqtt.client as mqtt
@@ -36,6 +37,12 @@ __all__ = [
 ]
 
 
+class MQTTTransport(Enum):
+    TCP = "tcp"
+    WEBSOCKETS = "websockets"
+    UNIX = "unix"
+
+
 class MQTTConfig(BaseModel):
     host: str
     username: str
@@ -44,7 +51,7 @@ class MQTTConfig(BaseModel):
     port: int = 1884
     timeout: int = 5
     use_tls: bool = False
-    transport: Literal["tcp", "websockets", "unix"] = "tcp"
+    transport: MQTTTransport = MQTTTransport.TCP
 
     @field_serializer("password", when_used="json")
     def dump_password(self, value):
@@ -143,7 +150,7 @@ class MQTTMessenger(types.Messenger):
             topic=config.topic,
             timeout=config.timeout,
             use_tls=config.use_tls,
-            transport=config.transport,
+            transport=config.transport.value,
             logger=logger,
         )
 

--- a/src/acoupi/system/config/parsers.py
+++ b/src/acoupi/system/config/parsers.py
@@ -2,6 +2,7 @@
 
 import argparse
 import datetime
+import enum
 import re
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
@@ -529,6 +530,43 @@ def parse_secret_str_field(
             click.echo(msg)
 
 
+def parse_enum_field(
+    field_name: str,
+    field: FieldInfo,
+    args: List[str],
+    prompt: bool = True,
+    prefix: str = "",
+) -> object:
+    parser = argparse.ArgumentParser()
+    name = f"--{prefix}.{field_name}" if prefix else f"--{field_name}"
+    parser.add_argument(
+        name,
+        dest="value",
+        type=str,
+        default=field.default,
+        help=field.description,
+    )
+    parsed_args, _ = parser.parse_known_args(args)
+
+    field_enum = field.annotation
+
+    if not issubclass(field_enum, enum.Enum):  # type: ignore
+        raise ValueError(f"Field {field} is not an enum.")
+
+    if not prompt:
+        return field_enum(parsed_args.value)
+
+    value = click.prompt(
+        (
+            "Please provide a value for "
+            f"{click.style(name, fg='blue', bold=True)}."
+            f"{field.description}"
+        ),
+        type=click.Choice([m.value for m in field_enum], case_sensitive=False),
+    )
+    return field_enum(value)
+
+
 FIELD_PARSERS: Dict[type, FieldParser] = {
     BaseModel: parse_pydantic_model_field_from_args,
     bool: build_simple_field_parser(cast_to_bool),
@@ -542,4 +580,5 @@ FIELD_PARSERS: Dict[type, FieldParser] = {
     datetime.datetime: build_simple_field_parser(datetime.datetime),
     Path: build_simple_field_parser(Path),
     SecretStr: parse_secret_str_field,
+    enum.Enum: parse_enum_field,
 }

--- a/tests/test_system/test_parsing.py
+++ b/tests/test_system/test_parsing.py
@@ -1,6 +1,7 @@
 """Test suite for config parsing functions."""
 
 import datetime
+import enum
 from argparse import ArgumentError
 from typing import List, Optional
 from unittest.mock import Mock
@@ -496,3 +497,37 @@ def test_custom_setup_parsing():
     assert isinstance(parsed_config, Schema)
     assert parsed_config.c is not None
     assert parsed_config.c.c == datetime.date(2021, 1, 1)
+
+
+def test_parse_enum_field():
+    class TestEnum(enum.Enum):
+        A = "a"
+        B = "b"
+
+    class Schema(BaseModel):
+        c: TestEnum
+
+    parsed_config = parse_config_from_args(
+        Schema,
+        ["--c", "a"],
+        prompt=False,
+    )
+
+    assert isinstance(parsed_config, Schema)
+    assert parsed_config.c == TestEnum.A
+
+
+def test_parse_enum_field_fails_if_not_valid_value():
+    class TestEnum(enum.Enum):
+        A = "a"
+        B = "b"
+
+    class Schema(BaseModel):
+        c: TestEnum
+
+    with pytest.raises(ValueError):
+        parse_config_from_args(
+            Schema,
+            ["--c", "c"],
+            prompt=False,
+        )


### PR DESCRIPTION
This PR fixes a regression introduced when the transport field was added to the MQTT messenger configuration. The issue stemmed from the use of a Literal type annotation, which was not supported by our configuration parser, causing parsing to fail.

To address this, I replaced the Literal with an Enum and added support for parsing Enum values. Since Enum types are easier to handle consistently within the parser, this approach simplifies the implementation while resolving the configuration parsing issue.