### PR TITLE
Refactor datetimes to be timezone aware and migrate to zoneinfo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ coverage:
 	$(ENV_PREFIX)coverage report -m
 	$(ENV_PREFIX)coverage html
 
+fix:
+	$(ENV_PREFIX)ruff check --fix $(SRC_DIR) $(TEST_DIR)
+
 lint/types:
 	$(ENV_PREFIX)ty check $(SRC_DIR) $(TEST_DIR)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
   "celery>=5.4.0",
   "Jinja2>=3.1.2",
   "pydantic-settings>=2.0.3",
-  "pytz>=2023.3.post1",
   "requests>=2.31.0",
   "eventlet>=0.36.1",
   "pygments>=2.18.0",

--- a/scripts/benchmark_metadata_store.py
+++ b/scripts/benchmark_metadata_store.py
@@ -401,7 +401,7 @@ def populate_stage_database(
     tags_per_detection: int,
 ) -> List[data.ModelOutput]:
     """Populate one stage database with existing recordings and detections."""
-    base_time = dt.datetime(2024, 1, 1, 12, 0, 0)
+    base_time = dt.datetime(2024, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
     recordings = [
         make_recording(deployment, recording_index, base_time)
         for recording_index in range(stage.existing_recordings)
@@ -455,11 +455,8 @@ def main() -> None:
     print(f"stages={args.stages or 'all'}")
     print()
 
-
     def load_recordings_for_management(paths: List[Path]) -> None:
-        recordings_and_info = store.get_recordings_info_by_path(
-            paths=paths
-        )
+        recordings_and_info = store.get_recordings_info_by_path(paths=paths)
         store.get_recordings_model_outputs(
             [recording for recording, _ in recordings_and_info]
         )
@@ -475,7 +472,7 @@ def main() -> None:
         store = SqliteStore(db_path)
         deployment = data.Deployment(
             name=f"benchmark-{stage.name}",
-            started_on=dt.datetime(2024, 1, 1, 0, 0, 0)
+            started_on=dt.datetime(2024, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc)
             + dt.timedelta(days=len(results)),
         )
         store.store_deployment(deployment)
@@ -492,7 +489,9 @@ def main() -> None:
             make_recording(
                 deployment=deployment,
                 recording_index=base_index + index,
-                base_time=dt.datetime(2024, 1, 1, 12, 0, 0),
+                base_time=dt.datetime(
+                    2024, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc
+                ),
             )
             for index in range(args.recording_batch_size)
         ]

--- a/scripts/benchmark_metadata_store.py
+++ b/scripts/benchmark_metadata_store.py
@@ -94,12 +94,6 @@ def build_parser() -> argparse.ArgumentParser:
         help="Number of predicted tags on each detection.",
     )
     parser.add_argument(
-        "--recording-tags",
-        type=int,
-        default=0,
-        help="Number of recording-level tags on each model output.",
-    )
-    parser.add_argument(
         "--keep-dbs",
         action="store_true",
         help="Keep generated sqlite databases after benchmarking.",
@@ -186,7 +180,7 @@ def make_detection(index: int, tags_per_detection: int) -> data.Detection:
         make_tag(index + tag_index, max(0.0, 0.99 - 0.01 * tag_index))
         for tag_index in range(tags_per_detection)
     ]
-    return data.Detection(
+    return data.PresenceDetection(
         location=data.BoundingBox.from_coordinates(
             start_time=float(index % 30) * 0.1,
             low_freq=1000.0 + float(index % 20) * 50.0,
@@ -220,7 +214,6 @@ def make_model_output(
     recording_index: int,
     detections_per_output: int,
     tags_per_detection: int,
-    recording_tags: int,
 ) -> data.ModelOutput:
     """Create one synthetic model output for a recording."""
     detections = [
@@ -230,14 +223,9 @@ def make_model_output(
         )
         for detection_index in range(detections_per_output)
     ]
-    tags = [
-        make_tag(recording_index + tag_index, 0.95)
-        for tag_index in range(recording_tags)
-    ]
     return data.ModelOutput(
         name_model="benchmark-model",
         recording=recording,
-        tags=tags,
         detections=detections,
         created_on=recording.created_on,
     )
@@ -339,17 +327,6 @@ def bulk_seed_stage_data(
             )
         )
 
-        for tag in model_output.tags:
-            predicted_tag_rows.append(
-                (
-                    tag.tag.key,
-                    tag.tag.value,
-                    tag.confidence_score,
-                    None,
-                    model_output.id.bytes,
-                )
-            )
-
         for detection in model_output.detections:
             location = detection.location
 
@@ -367,6 +344,7 @@ def bulk_seed_stage_data(
             detection_rows.append(
                 (
                     detection.id.bytes,
+                    "presence",
                     start_time_s,
                     low_freq_hz,
                     end_time_s,
@@ -383,7 +361,6 @@ def bulk_seed_stage_data(
                         tag.tag.value,
                         tag.confidence_score,
                         detection.id.bytes,
-                        None,
                     )
                 )
 
@@ -403,12 +380,12 @@ def bulk_seed_stage_data(
                 )
             if detection_rows:
                 connection.executemany(
-                    "INSERT INTO detection (id, start_time_s, low_freq_hz, end_time_s, high_freq_hz, detection_score, model_output_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    "INSERT INTO detection (id, prediction_type, start_time_s, low_freq_hz, end_time_s, high_freq_hz, detection_score, model_output_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                     detection_rows,
                 )
             if predicted_tag_rows:
                 connection.executemany(
-                    "INSERT INTO predicted_tag (key, value, confidence_score, detection_id, model_output_id) VALUES (?, ?, ?, ?, ?)",
+                    "INSERT INTO predicted_tag (key, value, confidence_score, detection_id) VALUES (?, ?, ?, ?)",
                     predicted_tag_rows,
                 )
             connection.commit()
@@ -422,7 +399,6 @@ def populate_stage_database(
     deployment: data.Deployment,
     stage: StageDefinition,
     tags_per_detection: int,
-    recording_tags: int,
 ) -> List[data.ModelOutput]:
     """Populate one stage database with existing recordings and detections."""
     base_time = dt.datetime(2024, 1, 1, 12, 0, 0)
@@ -437,7 +413,6 @@ def populate_stage_database(
             recording_index=index,
             detections_per_output=stage.detections_per_output,
             tags_per_detection=tags_per_detection,
-            recording_tags=recording_tags,
         )
         for index, recording in enumerate(recordings)
     ]
@@ -466,8 +441,6 @@ def main() -> None:
         raise SystemExit("--query-repetitions must be greater than 0")
     if args.tags_per_detection <= 0:
         raise SystemExit("--tags-per-detection must be greater than 0")
-    if args.recording_tags < 0:
-        raise SystemExit("--recording-tags must be 0 or greater")
 
     args.db_dir.mkdir(parents=True, exist_ok=True)
     results: List[BenchmarkResult] = []
@@ -479,9 +452,17 @@ def main() -> None:
     print(f"management_sample_size={args.management_sample_size}")
     print(f"query_repetitions={args.query_repetitions}")
     print(f"tags_per_detection={args.tags_per_detection}")
-    print(f"recording_tags={args.recording_tags}")
     print(f"stages={args.stages or 'all'}")
     print()
+
+
+    def load_recordings_for_management(paths: List[Path]) -> None:
+        recordings_and_info = store.get_recordings_info_by_path(
+            paths=paths
+        )
+        store.get_recordings_model_outputs(
+            [recording for recording, _ in recordings_and_info]
+        )
 
     for stage in select_stages(args.stages):
         print(f"Starting stage {stage}")
@@ -503,7 +484,6 @@ def main() -> None:
             deployment=deployment,
             stage=stage,
             tags_per_detection=args.tags_per_detection,
-            recording_tags=args.recording_tags,
         )
         print(" done")
 
@@ -522,7 +502,6 @@ def main() -> None:
                 recording_index=base_index + index,
                 detections_per_output=stage.detections_per_output,
                 tags_per_detection=args.tags_per_detection,
-                recording_tags=args.recording_tags,
             )
             for index, recording in enumerate(new_recordings)
         ]
@@ -564,14 +543,6 @@ def main() -> None:
             for model_output in all_outputs[:sample_size]
             if model_output.recording.path is not None
         ]
-
-        def load_recordings_for_management(paths: List[Path]) -> None:
-            recordings_and_info = store.get_recordings_info_by_path(
-                paths=paths
-            )
-            store.get_recordings_model_outputs(
-                [recording for recording, _ in recordings_and_info]
-            )
 
         print(f"Testing get {len(sample_paths)} recordings by path")
         results.append(

--- a/src/acoupi/components/audio_recorder.py
+++ b/src/acoupi/components/audio_recorder.py
@@ -14,7 +14,6 @@ audio recorder return a temporary .wav file.
 """
 
 import argparse
-import datetime
 import math
 import wave
 from pathlib import Path
@@ -102,7 +101,7 @@ class PyAudioRecorder(AudioRecorder):
         -------
         data.Recording: A Recording object containing the temporary path of the file.
         """
-        now = datetime.datetime.now()
+        now = data.utc_now()
         temp_path = self.audio_dir / f"{now.strftime('%Y%m%d_%H%M%S')}.wav"
         frames = self.get_recording_data(duration=self.duration)
         self.save_recording(frames, temp_path)

--- a/src/acoupi/components/message_stores/sqlite/queries.py
+++ b/src/acoupi/components/message_stores/sqlite/queries.py
@@ -1,7 +1,7 @@
 """SQLite message-store query helpers."""
 
 import sqlite3
-from datetime import datetime
+import datetime
 from typing import List
 from uuid import UUID
 
@@ -75,9 +75,12 @@ def store_response(
     )
 
 
-def serialise_datetime(value: datetime) -> str:
+def serialise_datetime(value: data.AwareDatetime) -> str:
     return value.isoformat(sep=" ")
 
 
-def parse_datetime(value: str) -> datetime:
-    return datetime.fromisoformat(value)
+def parse_datetime(value: str) -> data.AwareDatetime:
+    parsed = datetime.datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=datetime.timezone.utc)
+    return parsed

--- a/src/acoupi/components/message_stores/sqlite/queries.py
+++ b/src/acoupi/components/message_stores/sqlite/queries.py
@@ -1,7 +1,7 @@
 """SQLite message-store query helpers."""
 
-import sqlite3
 import datetime
+import sqlite3
 from typing import List
 from uuid import UUID
 

--- a/src/acoupi/components/messengers.py
+++ b/src/acoupi/components/messengers.py
@@ -227,7 +227,7 @@ class MQTTMessenger(types.Messenger):
         if response.rc != MQTTErrorCode.MQTT_ERR_SUCCESS:
             status = data.ResponseStatus.ERROR
 
-        received_on = datetime.datetime.now()
+        received_on = data.utc_now()
         logging.debug(f"Message sent: {message.content}")
 
         return data.Response(
@@ -416,7 +416,7 @@ class HTTPMessenger(types.Messenger):
                 f"HTTP send failed for message {message.id}: {error}"
             ) from error
 
-        received_on = datetime.datetime.now()
+        received_on = data.utc_now()
 
         return data.Response(
             content=response_content,

--- a/src/acoupi/components/messengers.py
+++ b/src/acoupi/components/messengers.py
@@ -13,7 +13,6 @@ The MQTTMessenger sends messages using the MQTT protocol. The HTTPMessenger
 sends messages using HTTP POST requests.
 """
 
-import datetime
 import json
 import logging
 import socket

--- a/src/acoupi/components/recording_schedulers.py
+++ b/src/acoupi/components/recording_schedulers.py
@@ -14,6 +14,7 @@ made.
 import datetime
 from typing import Optional
 
+from acoupi import data
 from acoupi.components.types import RecordingScheduler
 
 __all__ = [
@@ -38,7 +39,7 @@ class IntervalScheduler(RecordingScheduler):
         self.timeinterval = timeinterval
 
     def time_until_next_recording(
-        self, time: Optional[datetime.datetime] = None
+        self, time: Optional[data.AwareDatetime] = None
     ) -> float:
         """Provide the number of seconds until the next recording.
 
@@ -54,7 +55,7 @@ class IntervalScheduler(RecordingScheduler):
             Will return 0 if a recording should be made immediately.
         """
         if not time:
-            time = datetime.datetime.now()
+            time = data.utc_now()
         next_recording_time = (
             time + datetime.timedelta(seconds=self.timeinterval)
         ).replace(microsecond=0)

--- a/src/acoupi/components/stores/sqlite/queries.py
+++ b/src/acoupi/components/stores/sqlite/queries.py
@@ -219,7 +219,7 @@ def get_recordings_model_outputs(
 ) -> Dict[UUID, List[data.ModelOutput]]:
     recording_ids = list(recordings_by_id)
     model_output_rows: Dict[
-        UUID, List[Tuple[UUID, str, datetime.datetime]]
+        UUID, List[Tuple[UUID, str, data.AwareDatetime]]
     ] = defaultdict(list)
 
     for recording_id_chunk in chunked_uuids(recording_ids):
@@ -277,8 +277,8 @@ def get_recordings_model_outputs(
 
 def get_model_outputs(
     connection: sqlite3.Connection,
-    after: Optional[datetime.datetime] = None,
-    before: Optional[datetime.datetime] = None,
+    after: Optional[data.AwareDatetime] = None,
+    before: Optional[data.AwareDatetime] = None,
     ids: Optional[List[UUID]] = None,
     recording_ids: Optional[List[UUID]] = None,
     model_names: Optional[List[str]] = None,
@@ -366,8 +366,8 @@ def get_detections(
     score_gt: Optional[float] = None,
     score_lt: Optional[float] = None,
     model_names: Optional[List[str]] = None,
-    after: Optional[datetime.datetime] = None,
-    before: Optional[datetime.datetime] = None,
+    after: Optional[data.AwareDatetime] = None,
+    before: Optional[data.AwareDatetime] = None,
 ) -> List[data.Detection]:
     query = [
         """
@@ -454,8 +454,8 @@ def get_detections(
 def get_predicted_tags(
     connection: sqlite3.Connection,
     detection_ids: Optional[List[UUID]] = None,
-    after: Optional[datetime.datetime] = None,
-    before: Optional[datetime.datetime] = None,
+    after: Optional[data.AwareDatetime] = None,
+    before: Optional[data.AwareDatetime] = None,
     score_gt: Optional[float] = None,
     score_lt: Optional[float] = None,
     keys: Optional[List[str]] = None,
@@ -662,7 +662,7 @@ def get_predicted_tags_by_parent_ids(
         placeholders = ", ".join("?" for _ in id_chunk)
         rows = connection.execute(
             "SELECT key, value, confidence_score, "
-            f"{column_name} FROM predicted_tag WHERE {column_name} IN ({placeholders})",
+            f"{column_name} FROM predicted_tag WHERE {column_name} IN ({placeholders}) ORDER BY rowid",
             [id_value.bytes for id_value in id_chunk],
         ).fetchall()
 
@@ -725,9 +725,12 @@ def chunked_uuids(ids: List[UUID]) -> List[List[UUID]]:
     ]
 
 
-def serialise_datetime(value: datetime.datetime) -> str:
-    return value.isoformat(sep=" ")
+def serialise_datetime(value: data.AwareDatetime) -> str:
+    return value.isoformat()
 
 
-def parse_datetime(value: str) -> datetime.datetime:
-    return datetime.datetime.fromisoformat(value)
+def parse_datetime(value: str) -> data.AwareDatetime:
+    parsed = datetime.datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=datetime.timezone.utc)
+    return parsed

--- a/src/acoupi/components/stores/sqlite/store.py
+++ b/src/acoupi/components/stores/sqlite/store.py
@@ -94,7 +94,7 @@ class SqliteStore(types.Store):
             if deployment is not None:
                 return deployment
 
-            now = datetime.datetime.now()
+            now = data.utc_now()
             deployment = data.Deployment(
                 started_on=now,
                 name=f"Deployment {now.strftime('%Y-%m-%d %H:%M:%S')}",

--- a/src/acoupi/components/summariser.py
+++ b/src/acoupi/components/summariser.py
@@ -50,7 +50,7 @@ class StatisticsDetectionsSummariser(types.Summariser):
         self.store = store
         self.interval = interval
 
-    def build_summary(self, now: datetime.datetime) -> data.Message:
+    def build_summary(self, now: data.AwareDatetime) -> data.Message:
         """Build a message from a summary.
 
         Parameters
@@ -161,7 +161,7 @@ class ThresholdsDetectionsSummariser(types.Summariser):
         self.mid_band_threshold = mid_band_threshold
         self.high_band_threshold = high_band_threshold
 
-    def build_summary(self, now: datetime.datetime) -> data.Message:
+    def build_summary(self, now: data.AwareDatetime) -> data.Message:
         """Build a message from a summary.
 
         Parameters

--- a/src/acoupi/components/types.py
+++ b/src/acoupi/components/types.py
@@ -37,7 +37,7 @@ class RecordingScheduler(ABC):
     @abstractmethod
     def time_until_next_recording(
         self,
-        time: Optional[datetime.datetime] = None,
+        time: Optional[data.AwareDatetime] = None,
     ) -> float:
         """Provide the number of seconds until the next recording.
 

--- a/src/acoupi/data.py
+++ b/src/acoupi/data.py
@@ -4,12 +4,26 @@ import datetime
 from dataclasses import dataclass
 from enum import Enum, IntEnum
 from pathlib import Path
-from typing import Any, List, Optional, Sequence, Tuple, Union
+from typing import (
+    Any,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import (
+    AwareDatetime,
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+)
 
 __all__ = [
+    "AwareDatetime",
     "TimeInterval",
     "Deployment",
     "Recording",
@@ -26,6 +40,10 @@ __all__ = [
     "Response",
     "BoundingBox",
 ]
+
+
+def utc_now() -> AwareDatetime:
+    return datetime.datetime.now(datetime.timezone.utc)
 
 
 class TimeInterval(BaseModel):
@@ -67,12 +85,10 @@ class Deployment(BaseModel):
     longitude: Optional[float] = None
     """The longitude of the site where the device is deployed."""
 
-    started_on: datetime.datetime = Field(
-        default_factory=datetime.datetime.now
-    )
+    started_on: AwareDatetime = Field(default_factory=utc_now)
     """The datetime when the device was deployed."""
 
-    ended_on: Optional[datetime.datetime] = None
+    ended_on: Optional[AwareDatetime] = None
     """The datetime when the deployment ended."""
 
     @field_validator("latitude")
@@ -93,10 +109,7 @@ class Deployment(BaseModel):
 class Recording(BaseModel):
     """A Recording is a single audio file recorded from the microphone."""
 
-    created_on: datetime.datetime = Field(
-        default_factory=datetime.datetime.now,
-        repr=False,
-    )
+    created_on: AwareDatetime = Field(default_factory=utc_now, repr=False)
     """The datetime when the recording was made"""
 
     duration: float = Field(
@@ -358,9 +371,7 @@ class ModelOutput(BaseModel):
     detections: Sequence[Detection] = Field(default_factory=list)
     """List of predicted sound events in the recording."""
 
-    created_on: datetime.datetime = Field(
-        default_factory=lambda: datetime.datetime.now(datetime.timezone.utc)
-    )
+    created_on: AwareDatetime = Field(default_factory=utc_now)
     """The datetime when the model output was created."""
 
     def __eq__(self, other: Any) -> bool:
@@ -388,9 +399,7 @@ class ModelOutputInfo(BaseModel):
     name_model: str
     """The name of the model that produced the output."""
 
-    created_on: datetime.datetime = Field(
-        default_factory=lambda: datetime.datetime.now(datetime.timezone.utc)
-    )
+    created_on: AwareDatetime = Field(default_factory=utc_now)
     """The datetime when the model output was created."""
 
 
@@ -403,9 +412,7 @@ class Message(BaseModel):
     content: Union[str, bytes]
     """The message to be sent. Usually JSON text, but may be raw bytes."""
 
-    created_on: datetime.datetime = Field(
-        default_factory=lambda: datetime.datetime.now(datetime.timezone.utc)
-    )
+    created_on: AwareDatetime = Field(default_factory=utc_now)
     """The datetime when the message was created."""
 
 
@@ -437,7 +444,5 @@ class Response(BaseModel):
     content: Optional[str] = None
     """The content of the response."""
 
-    received_on: datetime.datetime = Field(
-        default_factory=lambda: datetime.datetime.now(datetime.timezone.utc)
-    )
+    received_on: AwareDatetime = Field(default_factory=utc_now)
     """The datetime the message was received."""

--- a/src/acoupi/programs/connected.py
+++ b/src/acoupi/programs/connected.py
@@ -53,8 +53,8 @@ and sending messages and heartbeats according to the configured settings.
 
 import datetime
 from typing import Optional
+from zoneinfo import ZoneInfo
 
-import pytz
 from pydantic import BaseModel
 
 from acoupi import components, data
@@ -106,7 +106,7 @@ class Program(MessagingProgram):
             return []
 
         saving_filters = []
-        timezone = pytz.timezone(config.timezone)
+        timezone = ZoneInfo(config.timezone)
         recording_saving = config.recording_saving
 
         # Main filter

--- a/src/acoupi/programs/default.py
+++ b/src/acoupi/programs/default.py
@@ -6,8 +6,8 @@ do any processing and messaging.
 
 import datetime
 from typing import Optional
+from zoneinfo import ZoneInfo
 
-import pytz
 from pydantic import BaseModel
 
 from acoupi import components, data
@@ -48,7 +48,7 @@ class Program(BasicProgram):
             return []
 
         saving_filters = []
-        timezone = pytz.timezone(config.timezone)
+        timezone = ZoneInfo(config.timezone)
         recording_saving = config.recording_saving
 
         # Main filter

--- a/src/acoupi/system/__init__.py
+++ b/src/acoupi/system/__init__.py
@@ -22,6 +22,7 @@ from acoupi.system.config import (
     write_config,
 )
 from acoupi.system.constants import Settings
+from acoupi.system.datetime import get_system_timezone, set_system_timezone
 from acoupi.system.deployments import (
     end_deployment,
     get_current_deployment,
@@ -64,6 +65,7 @@ __all__ = [
     "get_config_field",
     "get_current_deployment",
     "get_status",
+    "get_system_timezone",
     "get_task_list",
     "get_temp_file_id",
     "get_temp_files",
@@ -81,6 +83,7 @@ __all__ = [
     "run_task",
     "services_are_installed",
     "set_config_field",
+    "set_system_timezone",
     "setup_program",
     "start_deployment",
     "start_program",

--- a/src/acoupi/system/datetime.py
+++ b/src/acoupi/system/datetime.py
@@ -1,0 +1,66 @@
+"""System datetime management."""
+
+import subprocess
+from typing import Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+__all__ = ["get_system_timezone", "set_system_timezone"]
+
+
+def get_system_timezone() -> Optional[str]:
+    """Get the current system timezone.
+
+    Returns
+    -------
+    Optional[str]
+        The timezone string (e.g., 'Europe/London') or None if it cannot be
+        determined.
+    """
+    try:
+        # Run timedatectl to get the current timezone
+        result = subprocess.run(
+            ["timedatectl", "show", "--property=Timezone", "--value"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        tz_string = result.stdout.strip()
+
+        if tz_string:
+            return tz_string
+
+    except subprocess.CalledProcessError:
+        pass
+
+    return None
+
+
+def set_system_timezone(timezone_str: str) -> bool:
+    """Set the system timezone using timedatectl.
+
+    Parameters
+    ----------
+    timezone_str : str
+        The timezone to set (e.g., 'America/New_York').
+
+    Returns
+    -------
+    bool
+        True if successful, False otherwise.
+    """
+    # 1. Validate that the requested timezone actually exists
+    try:
+        ZoneInfo(timezone_str)
+    except ZoneInfoNotFoundError:
+        return False
+
+    # 2. Attempt to set it using timedatectl
+    try:
+        subprocess.run(
+            ["sudo", "timedatectl", "set-timezone", timezone_str],
+            check=True,
+            capture_output=True,
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False

--- a/src/acoupi/system/datetime.py
+++ b/src/acoupi/system/datetime.py
@@ -7,7 +7,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 __all__ = ["get_system_timezone", "set_system_timezone"]
 
 
-def get_system_timezone() -> Optional[str]:
+def get_system_timezone() -> Optional[ZoneInfo]:
     """Get the current system timezone.
 
     Returns
@@ -17,7 +17,6 @@ def get_system_timezone() -> Optional[str]:
         determined.
     """
     try:
-        # Run timedatectl to get the current timezone
         result = subprocess.run(
             ["timedatectl", "show", "--property=Timezone", "--value"],
             capture_output=True,
@@ -26,13 +25,17 @@ def get_system_timezone() -> Optional[str]:
         )
         tz_string = result.stdout.strip()
 
-        if tz_string:
-            return tz_string
-
     except subprocess.CalledProcessError:
-        pass
+        return None
 
-    return None
+    if not tz_string:
+        return None
+
+    try:
+        return ZoneInfo(tz_string)
+
+    except ZoneInfoNotFoundError:
+        return None
 
 
 def set_system_timezone(timezone_str: str) -> bool:
@@ -48,13 +51,11 @@ def set_system_timezone(timezone_str: str) -> bool:
     bool
         True if successful, False otherwise.
     """
-    # 1. Validate that the requested timezone actually exists
     try:
         ZoneInfo(timezone_str)
     except ZoneInfoNotFoundError:
         return False
 
-    # 2. Attempt to set it using timedatectl
     try:
         subprocess.run(
             ["sudo", "timedatectl", "set-timezone", timezone_str],

--- a/src/acoupi/system/deployments.py
+++ b/src/acoupi/system/deployments.py
@@ -4,7 +4,6 @@ This module contains utility functions for acoupi programs
 such as loading programs and getting celery apps from programs.
 """
 
-import datetime
 from pathlib import Path
 from typing import Optional
 
@@ -57,7 +56,7 @@ def start_deployment(
 
     deployment = data.Deployment(
         name=name,
-        started_on=datetime.datetime.now(),
+        started_on=data.utc_now(),
         latitude=latitude,
         longitude=longitude,
     )
@@ -115,7 +114,7 @@ def end_deployment(settings: Settings) -> data.Deployment:
         If the deployment has already ended or has not been started yet.
     """
     deployment = get_current_deployment(settings)
-    deployment.ended_on = datetime.datetime.now()
+    deployment.ended_on = data.utc_now()
     write_deployment_to_file(deployment, settings.deployment_file)
     return deployment
 

--- a/src/acoupi/tasks/heartbeat.py
+++ b/src/acoupi/tasks/heartbeat.py
@@ -5,7 +5,7 @@ from typing import Callable, List
 from pydantic import BaseModel, Field
 
 from acoupi.components import types
-from acoupi.data import Message
+from acoupi.data import Message, utc_now
 from acoupi.devices import get_device_id
 
 logger = logging.getLogger(__name__)
@@ -13,7 +13,7 @@ logger.setLevel(logging.INFO)
 
 
 class Heartbeat(BaseModel):
-    sent_on: datetime.datetime = Field(default_factory=datetime.datetime.now)
+    sent_on: datetime.datetime = Field(default_factory=utc_now)
     device_id: str
     status: str = "OK"
 
@@ -47,7 +47,7 @@ def generate_heartbeat_task(
     def heartbeat_task() -> None:
         device_id = get_device_id()
 
-        now = datetime.datetime.now()
+        now = utc_now()
 
         heartbeat = Heartbeat(device_id=device_id, sent_on=now)
         message = Message(

--- a/src/acoupi/tasks/summary.py
+++ b/src/acoupi/tasks/summary.py
@@ -14,6 +14,7 @@ import logging
 from typing import Callable, List
 
 from acoupi.components import types
+from acoupi.data import utc_now
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -53,7 +54,7 @@ def generate_summariser_task(
 
     def summary_task() -> None:
         """Create a summary message."""
-        now = datetime.datetime.now()
+        now = utc_now()
 
         for summariser in summarisers:
             logger.info(f"SUMMARISER: {summariser}")

--- a/src/acoupi/tasks/summary.py
+++ b/src/acoupi/tasks/summary.py
@@ -9,7 +9,6 @@ following steps:
 2. Store the summary message in the message store.
 """
 
-import datetime
 import logging
 from typing import Callable, List
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,15 +91,20 @@ def patched_now(monkeypatch):
 
     Example:
         def test_foo(patched_now):
-            now = patched_now(datetime.datetime(2020, 1, 1))
+            now = patched_now(datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc))
             assert datetime.datetime.now() == now
     """
-    _now = dt.datetime.now()
+    _now = data.utc_now()
 
     def set_now(time: dt.datetime = _now):
         class fake_datetime:
             @classmethod
             def now(cls, *args, **kwargs):
+                tz = kwargs.get("tz")
+                if tz is None and args:
+                    tz = args[0]
+                if tz is not None and time.tzinfo is not None:
+                    return time.astimezone(tz)
                 return time
 
         monkeypatch.setattr(
@@ -125,7 +130,7 @@ def recording(deployment: data.Deployment) -> data.Recording:
         path=Path("tests"),
         duration=1,
         samplerate=16000,
-        created_on=dt.datetime.now(),
+        created_on=data.utc_now(),
         deployment=deployment,
     )
 

--- a/tests/test_components/test_file_managers.py
+++ b/tests/test_components/test_file_managers.py
@@ -18,7 +18,7 @@ def test_save_recording_manager_fails_if_recording_has_no_path(
         path=None,
         duration=1,
         samplerate=8000,
-        created_on=datetime.datetime.now(),
+        created_on=data.utc_now(),
         deployment=deployment,
     )
 
@@ -37,7 +37,7 @@ def test_save_recording_with_confident_tags(tmp_path: Path):
         path=recording_file,
         duration=1,
         samplerate=8000,
-        created_on=datetime.datetime.now(),
+        created_on=data.utc_now(),
         deployment=data.Deployment(name="test"),
     )
     model_output = data.ModelOutput(
@@ -82,7 +82,7 @@ def test_save_recording_with_unconfident_tags(tmp_path: Path):
         path=recording_file,
         duration=1,
         samplerate=8000,
-        created_on=datetime.datetime.now(),
+        created_on=data.utc_now(),
         deployment=data.Deployment(name="test"),
     )
     model_output = data.ModelOutput(
@@ -138,7 +138,15 @@ def test_date_file_manager_save_recording(
         path=path,
         duration=1,
         samplerate=8000,
-        created_on=datetime.datetime(year, month, day, hour, minute, second),
+        created_on=datetime.datetime(
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            tzinfo=datetime.timezone.utc,
+        ),
         deployment=deployment,
     )
     # make sure the recording file exists
@@ -168,7 +176,9 @@ def test_date_file_manager_supports_custom_filename_template(
         duration=1.5,
         samplerate=48000,
         audio_channels=2,
-        created_on=datetime.datetime(2023, 4, 15, 18, 9, 30),
+        created_on=datetime.datetime(
+            2023, 4, 15, 18, 9, 30, tzinfo=datetime.timezone.utc
+        ),
         deployment=data.Deployment(
             name="My Site/1",
             latitude=51.5,
@@ -204,7 +214,9 @@ def test_date_file_manager_uses_empty_device_id_when_unavailable(
         path=path,
         duration=1,
         samplerate=48000,
-        created_on=datetime.datetime(2023, 4, 15, 18, 9, 30),
+        created_on=datetime.datetime(
+            2023, 4, 15, 18, 9, 30, tzinfo=datetime.timezone.utc
+        ),
         deployment=data.Deployment(name="site-a"),
     )
     path.touch()
@@ -234,7 +246,9 @@ def test_date_file_manager_fails_with_invalid_filename_template(
         path=path,
         duration=1,
         samplerate=8000,
-        created_on=datetime.datetime(2023, 4, 15, 18, 9, 30),
+        created_on=datetime.datetime(
+            2023, 4, 15, 18, 9, 30, tzinfo=datetime.timezone.utc
+        ),
         deployment=deployment,
     )
     path.touch()
@@ -266,7 +280,15 @@ def test_date_file_manager_fails_if_recording_has_no_path(
         path=None,
         duration=1,
         samplerate=8000,
-        created_on=datetime.datetime(year, month, day, hour, minute, second),
+        created_on=datetime.datetime(
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            tzinfo=datetime.timezone.utc,
+        ),
         deployment=deployment,
     )
 
@@ -297,7 +319,15 @@ def test_date_file_manager_fails_if_recording_file_does_not_exist(
         path=path,
         duration=1,
         samplerate=8000,
-        created_on=datetime.datetime(year, month, day, hour, minute, second),
+        created_on=datetime.datetime(
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            tzinfo=datetime.timezone.utc,
+        ),
         deployment=deployment,
     )
 
@@ -328,7 +358,7 @@ def test_id_file_manager_save_recording(
         path=path,
         duration=1,
         samplerate=8000,
-        created_on=datetime.datetime.now(),
+        created_on=data.utc_now(),
         deployment=deployment,
     )
     # make sure the recording file exists
@@ -357,7 +387,7 @@ def test_id_file_manager_fails_if_recording_has_no_path(
         path=None,
         duration=1,
         samplerate=8000,
-        created_on=datetime.datetime.now(),
+        created_on=data.utc_now(),
         deployment=deployment,
     )
 
@@ -382,7 +412,7 @@ def test_id_file_manager_fails_if_recording_file_does_not_exist(
         path=path,
         duration=1,
         samplerate=8000,
-        created_on=datetime.datetime.now(),
+        created_on=data.utc_now(),
         deployment=deployment,
     )
 

--- a/tests/test_components/test_message_builders.py
+++ b/tests/test_components/test_message_builders.py
@@ -17,7 +17,9 @@ TEST_MODEL_OUTPUT = data.ModelOutput(
         ),
         duration=1,
         samplerate=192000,
-        created_on=datetime.datetime(2020, 1, 1, 0, 0, 0),
+        created_on=datetime.datetime(
+            2020, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
+        ),
     ),
     detections=[
         data.PresenceDetection(

--- a/tests/test_components/test_message_factories.py
+++ b/tests/test_components/test_message_factories.py
@@ -56,7 +56,7 @@ def create_test_model_output():
         samplerate=256000,
         audio_channels=1,
         deployment=deployment,
-        created_on=datetime.datetime.now(),
+        created_on=data.utc_now(),
     )
 
     def factory(

--- a/tests/test_components/test_message_factories.py
+++ b/tests/test_components/test_message_factories.py
@@ -1,6 +1,5 @@
 """Test acoupi components saving filters."""
 
-import datetime
 from pathlib import Path
 from typing import List
 

--- a/tests/test_components/test_messengers.py
+++ b/tests/test_components/test_messengers.py
@@ -1,6 +1,5 @@
 """Test suite for acoupi messengers."""
 
-import datetime
 from pathlib import Path
 from unittest import mock
 

--- a/tests/test_components/test_messengers.py
+++ b/tests/test_components/test_messengers.py
@@ -225,7 +225,7 @@ def test_http_messenger_with_complex_message():
                 path=Path("test_recording.wav"),
                 duration=1,
                 samplerate=16000,
-                created_on=datetime.datetime.now(),
+                created_on=data.utc_now(),
                 deployment=data.Deployment(
                     name="test_deployment",
                 ),

--- a/tests/test_components/test_model.py
+++ b/tests/test_components/test_model.py
@@ -52,7 +52,7 @@ def test_model(deployment: data.Deployment):
         path=Path("tests/data/test_ultrasonic.wav"),
         duration=1,
         samplerate=16000,
-        created_on=datetime.datetime.now(),
+        created_on=data.utc_now(),
         deployment=deployment,
     )
     model = MockModel()

--- a/tests/test_components/test_model.py
+++ b/tests/test_components/test_model.py
@@ -1,6 +1,5 @@
 """Test running the model of a recorded audio file."""
 
-import datetime
 from pathlib import Path
 
 from acoupi import data

--- a/tests/test_components/test_output_cleaners.py
+++ b/tests/test_components/test_output_cleaners.py
@@ -1,6 +1,5 @@
 """Test output cleaners."""
 
-import datetime
 from pathlib import Path
 from typing import List
 

--- a/tests/test_components/test_output_cleaners.py
+++ b/tests/test_components/test_output_cleaners.py
@@ -23,7 +23,7 @@ def create_test_model_output():
         samplerate=256000,
         audio_channels=1,
         deployment=deployment,
-        created_on=datetime.datetime.now(),
+        created_on=data.utc_now(),
     )
 
     def factory(

--- a/tests/test_components/test_recording_conditions.py
+++ b/tests/test_components/test_recording_conditions.py
@@ -14,7 +14,7 @@ def test_single_interval_recording_manager(patched_now):
         end=datetime.time(11, 0),
     )
 
-    now = datetime.datetime.now().replace(
+    now = data.utc_now().replace(
         hour=0,
         minute=0,
         second=0,
@@ -55,7 +55,7 @@ def test_multiple_interval_recording_manager(patched_now):
         ),
     ]
 
-    now = datetime.datetime.now().replace(
+    now = data.utc_now().replace(
         hour=0,
         minute=0,
         second=0,

--- a/tests/test_components/test_saving_filters.py
+++ b/tests/test_components/test_saving_filters.py
@@ -4,9 +4,9 @@ import datetime
 import tempfile
 from pathlib import Path
 from typing import List
+from zoneinfo import ZoneInfo
 
 import pytest
-import pytz
 from astral import LocationInfo
 from astral.sun import sun
 
@@ -87,7 +87,7 @@ def create_test_model_output():
         samplerate=256000,
         audio_channels=1,
         deployment=deployment,
-        created_on=datetime.datetime.now(),
+        created_on=data.utc_now(),
     )
 
     def factory(
@@ -116,7 +116,9 @@ def test_save_recording_ifin_interval(
         end=datetime.time(4, 0, 0),
     )
     recording = create_test_recording(
-        recording_time=datetime.datetime(2024, 8, 1, 23, 0, 0),
+        recording_time=datetime.datetime(
+            2024, 8, 1, 23, 0, 0, tzinfo=datetime.timezone.utc
+        ),
     )
 
     saving_filter = saving_filters.SaveIfInInterval(
@@ -139,7 +141,9 @@ def test_delete_recording_ifnotin_interval(
         end=datetime.time(4, 0, 0),
     )
     recording = create_test_recording(
-        recording_time=datetime.datetime(2024, 8, 1, 12, 0, 0),
+        recording_time=datetime.datetime(
+            2024, 8, 1, 12, 0, 0, tzinfo=datetime.timezone.utc
+        ),
     )
 
     saving_filter = saving_filters.SaveIfInInterval(
@@ -161,7 +165,7 @@ def test_before_dawndusk_time_interval(
     """Test if a recording is saved if it is in the interval."""
     # Setup
     interval_duration: float = 20  # in minutes
-    timezone = pytz.timezone("Europe/London")
+    timezone = ZoneInfo("Europe/London")
 
     saving_filter = saving_filters.Before_DawnDuskTimeInterval(
         duration=interval_duration, timezone=timezone
@@ -218,7 +222,7 @@ def test_after_dawndusk_time_interval(
     """Test if a recording is saved if it is in the interval."""
     # Setup
     interval_duration: float = 20  # in minutes
-    timezone = pytz.timezone("Europe/London")
+    timezone = ZoneInfo("Europe/London")
 
     saving_filter = saving_filters.After_DawnDuskTimeInterval(
         duration=interval_duration, timezone=timezone
@@ -284,7 +288,9 @@ def test_delete_recording_without_detections(
         temp_path = tmpfile.name
 
     recording = create_test_recording(
-        recording_time=datetime.datetime(2024, 8, 1, 20, 0, 0),
+        recording_time=datetime.datetime(
+            2024, 8, 1, 20, 0, 0, tzinfo=datetime.timezone.utc
+        ),
         recording_path=Path(temp_path),
     )
 
@@ -312,7 +318,9 @@ def test_save_recording_ifboth_detclassprob_above_savingthreshold(
     # Setup
     saving_threshold = 0.6
     recording = create_test_recording(
-        recording_time=datetime.datetime(2024, 8, 1, 20, 0, 0),
+        recording_time=datetime.datetime(
+            2024, 8, 1, 20, 0, 0, tzinfo=datetime.timezone.utc
+        ),
     )
     model_output = create_test_model_output(
         detections=[
@@ -350,7 +358,9 @@ def test_save_recording_if_onlydetprob_above_savingthreshold(
     # Setup
     saving_threshold = 0.6
     recording = create_test_recording(
-        recording_time=datetime.datetime(2024, 8, 1, 20, 0, 0),
+        recording_time=datetime.datetime(
+            2024, 8, 1, 20, 0, 0, tzinfo=datetime.timezone.utc
+        ),
     )
     model_output = create_test_model_output(
         detections=[
@@ -392,7 +402,9 @@ def test_delete_recording_if_detclassprob_below_savingthreshold(
         temp_path = tmpfile.name
 
     recording = create_test_recording(
-        recording_time=datetime.datetime(2024, 8, 1, 20, 0, 0),
+        recording_time=datetime.datetime(
+            2024, 8, 1, 20, 0, 0, tzinfo=datetime.timezone.utc
+        ),
         recording_path=Path(temp_path),
     )
     model_output = create_test_model_output(
@@ -434,7 +446,9 @@ def test_save_recording_with_focus_tagvalues(
     """Test if the recording is saved if it contains a focus tag value (e.g., name of a species)."""
     # Setup
     recording = create_test_recording(
-        recording_time=datetime.datetime(2024, 8, 1, 20, 0, 0),
+        recording_time=datetime.datetime(
+            2024, 8, 1, 20, 0, 0, tzinfo=datetime.timezone.utc
+        ),
     )
     focus_species = ["species_1", "species_2"]
     model_output = create_test_model_output(
@@ -470,7 +484,9 @@ def test_delete_recording_ifnot_focus_tagvalues(
     """Test if the recording is saved if it contains the focus species."""
     # Setup
     recording = create_test_recording(
-        recording_time=datetime.datetime(2024, 8, 1, 20, 0, 0),
+        recording_time=datetime.datetime(
+            2024, 8, 1, 20, 0, 0, tzinfo=datetime.timezone.utc
+        ),
     )
     focus_species = ["species_1", "species_2"]
     model_output = create_test_model_output(

--- a/tests/test_components/test_saving_managers.py
+++ b/tests/test_components/test_saving_managers.py
@@ -84,7 +84,7 @@ def create_test_model_output():
         samplerate=256000,
         audio_channels=1,
         deployment=deployment,
-        created_on=datetime.datetime.now(),
+        created_on=data.utc_now(),
     )
 
     def factory(
@@ -107,7 +107,9 @@ def test_save_recording_manager_fails_if_recording_has_no_path(
     saving_manager = saving_managers.SaveRecordingManager(tmp_path)
     recording = create_test_recording(
         recording_path=None,
-        recording_time=datetime.datetime(2020, 1, 1, 0, 0, 0),
+        recording_time=datetime.datetime(
+            2020, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
+        ),
     )
     with pytest.raises(ValueError):
         saving_manager.save_recording(recording)
@@ -135,7 +137,9 @@ def test_save_recording_with_confident_detections(
     recording_file.write_text("test recording in true_detections folder")
 
     recording = create_test_recording(
-        recording_time=datetime.datetime(2020, 1, 1, 0, 0, 0),
+        recording_time=datetime.datetime(
+            2020, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
+        ),
         recording_path=recording_file,
     )
 
@@ -192,7 +196,9 @@ def test_save_recording_with_unconfident_detections(
     )
 
     recording = create_test_recording(
-        recording_time=datetime.datetime(2020, 1, 1, 0, 0, 0),
+        recording_time=datetime.datetime(
+            2020, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
+        ),
         recording_path=recording_file,
     )
     model_output = create_test_model_output(
@@ -246,7 +252,9 @@ def test_none_is_returned_if_not_true_or_false_class(
     recording_file.write_text("test recording going to right folder")
 
     recording = create_test_recording(
-        recording_time=datetime.datetime(2020, 1, 1, 0, 0, 0),
+        recording_time=datetime.datetime(
+            2020, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
+        ),
         recording_path=recording_file,
     )
 
@@ -291,7 +299,9 @@ def test_date_file_manager_save_recording(
     recording_file.touch()
 
     recording = create_test_recording(
-        recording_time=datetime.datetime(2024, 8, 1, 20, 30, 0),
+        recording_time=datetime.datetime(
+            2024, 8, 1, 20, 30, 0, tzinfo=datetime.timezone.utc
+        ),
         recording_path=recording_file,
     )
 

--- a/tests/test_components/test_stores/test_sqlite/test_queries.py
+++ b/tests/test_components/test_stores/test_sqlite/test_queries.py
@@ -31,7 +31,7 @@ def build_recording(
     deployment: data.Deployment,
     *,
     path: str,
-    created_on: datetime.datetime,
+    created_on: data.AwareDatetime,
 ) -> data.Recording:
     return data.Recording(
         deployment=deployment,
@@ -46,7 +46,7 @@ def build_model_output(
     recording: data.Recording,
     *,
     name_model: str,
-    created_on: datetime.datetime,
+    created_on: data.AwareDatetime,
     detection_score: float,
     detection_tag: tuple[str, str, float],
 ) -> data.ModelOutput:
@@ -114,7 +114,7 @@ class TestGetRecordingsByIds:
             path=Path("first.wav"),
             duration=1.0,
             samplerate=16000,
-            created_on=datetime.datetime.now(),
+            created_on=data.utc_now(),
         )
         second = first.model_copy(
             update=dict(

--- a/tests/test_components/test_stores/test_sqlite/test_store.py
+++ b/tests/test_components/test_stores/test_sqlite/test_store.py
@@ -136,7 +136,7 @@ def test_can_instantiate_multiple_stores_with_the_same_sqlite_file(
 def test_can_store_a_deployment(sqlite_store: components.SqliteStore) -> None:
     """Test that we can store a deployment."""
     # Arrange
-    now = datetime.datetime.now()
+    now = data.utc_now()
     deployment = data.Deployment(
         started_on=now,
         latitude=1.0,
@@ -153,7 +153,7 @@ def test_can_store_a_deployment(sqlite_store: components.SqliteStore) -> None:
         cursor = conn.cursor()
         cursor.execute("SELECT * FROM deployment;")
         row = cursor.fetchone()
-        assert row["started_on"] == now.isoformat(sep=" ")
+        assert row["started_on"] == now.isoformat()
         assert row["latitude"] == 1.0
         assert row["longitude"] == 2.0
 
@@ -187,8 +187,8 @@ def test_get_current_deployment_gets_latest_deployment(
 ) -> None:
     """Test that get_current_deployment gets the latest deployment."""
     # Arrange
-    start_1 = datetime.datetime.now()
-    start_2 = datetime.datetime.now() - datetime.timedelta(days=10)
+    start_1 = data.utc_now()
+    start_2 = data.utc_now() - datetime.timedelta(days=10)
     deployment1 = data.Deployment(
         started_on=start_1,
         latitude=1.0,
@@ -216,7 +216,7 @@ def test_deployment_id_in_db_is_same_as_in_python(
 ) -> None:
     """Test that the deployment_id in the db is the same as in python."""
     # Arrange
-    now = datetime.datetime.now()
+    now = data.utc_now()
     deployment = data.Deployment(
         started_on=now,
         latitude=1.0,
@@ -242,7 +242,7 @@ def test_recordings_can_be_registered(
 ) -> None:
     """Test that recordings can be registered."""
     # Arrange
-    now = datetime.datetime.now()
+    now = data.utc_now()
     recording = data.Recording(
         deployment=deployment,
         path=Path("test/path"),
@@ -265,7 +265,7 @@ def test_recordings_can_be_registered(
         assert row["duration_s"] == 10.0
         assert row["audio_channels"] == 2
         assert row["samplerate_hz"] == 44100
-        assert row["datetime"] == now.isoformat(sep=" ")
+        assert row["datetime"] == now.isoformat()
         assert row["id"] == recording.id.bytes
 
 
@@ -274,7 +274,7 @@ def test_recording_can_be_registered_with_custom_deployment(
 ):
     """Test that recordings can be registered with a custom deployment."""
     # Arrange
-    now = datetime.datetime.now()
+    now = data.utc_now()
     deployment = data.Deployment(
         started_on=now,
         latitude=1.0,
@@ -302,7 +302,7 @@ def test_recording_can_be_registered_with_custom_deployment(
         assert row["path"] == "test/path"
         assert row["duration_s"] == 10.0
         assert row["samplerate_hz"] == 44100
-        assert row["datetime"] == now.isoformat(sep=" ")
+        assert row["datetime"] == now.isoformat()
         assert row["id"] == recording.id.bytes
         assert row["deployment_id"] == deployment.id.bytes
 
@@ -315,7 +315,7 @@ def test_get_all_recordings(
     # Arrange
 
     # Create two recordings
-    now = datetime.datetime.now()
+    now = data.utc_now()
     recording1 = data.Recording(
         deployment=deployment,
         path=Path("test/path1"),
@@ -352,7 +352,7 @@ def test_get_some_recordings(
     # Arrange
 
     # Create two recordings
-    now = datetime.datetime.now()
+    now = data.utc_now()
     recording1 = data.Recording(
         deployment=deployment,
         path=Path("test/path1"),
@@ -591,7 +591,7 @@ def test_get_recordings_model_outputs_chunks_large_batches(
 
     recordings = []
     model_outputs = []
-    base_time = datetime.datetime.now()
+    base_time = data.utc_now()
     for index in range(5):
         recording = data.Recording(
             deployment=deployment,
@@ -681,7 +681,7 @@ def test_in_memory_store_supports_batched_model_output_loads(
             path=Path("test/in-memory.wav"),
             duration=10.0,
             samplerate=44100,
-            created_on=datetime.datetime.now(),
+            created_on=data.utc_now(),
         )
 
         sqlite_store.store_recording(recording)
@@ -694,7 +694,7 @@ def test_in_memory_store_supports_batched_model_output_loads(
 def test_can_update_deployment_info(
     sqlite_store: components.SqliteStore,
 ):
-    start = datetime.datetime.now()
+    start = data.utc_now()
     deployment = data.Deployment(
         started_on=start,
         latitude=1.0,
@@ -722,7 +722,7 @@ def test_can_update_deployment_info(
 def test_update_deployment_fails_if_corresponding_deployment_does_not_exist(
     sqlite_store: components.SqliteStore,
 ):
-    start = datetime.datetime.now()
+    start = data.utc_now()
     deployment = data.Deployment(
         started_on=start,
         latitude=1.0,

--- a/tests/test_components/test_summariser.py
+++ b/tests/test_components/test_summariser.py
@@ -11,7 +11,7 @@ from acoupi.components.summariser import ThresholdsDetectionsSummariser
 
 def test_build_summary(tmp_path: Path) -> None:
     """Build a threshold-based summary message."""
-    now = datetime.datetime(2024, 1, 1, 12, 0, 0)
+    now = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     deployment = data.Deployment(name="test_deployment")
     recording = data.Recording(
         path=tmp_path / "test.wav",

--- a/tests/test_programs/test_basic_template.py
+++ b/tests/test_programs/test_basic_template.py
@@ -71,11 +71,21 @@ def test_basic_program_registers_deployment_in_store_on_end(
         name="test",
         latitude=12,
         longitude=32,
-        started_on=datetime.datetime(year=2024, month=7, day=1),
+        started_on=datetime.datetime(
+            year=2024,
+            month=7,
+            day=1,
+            tzinfo=datetime.timezone.utc,
+        ),
     )
     program.on_start(deployment)
 
-    deployment.ended_on = datetime.datetime(year=2024, month=8, day=10)
+    deployment.ended_on = datetime.datetime(
+        year=2024,
+        month=8,
+        day=10,
+        tzinfo=datetime.timezone.utc,
+    )
     program.on_end(deployment)
 
     current = program.store.get_current_deployment()

--- a/tests/test_system/test_datetime.py
+++ b/tests/test_system/test_datetime.py
@@ -1,0 +1,44 @@
+import subprocess
+from unittest.mock import Mock
+
+from acoupi.system.datetime import get_system_timezone, set_system_timezone
+
+
+def test_get_system_timezone(mocker):
+    mock_run = mocker.patch("acoupi.system.datetime.subprocess.run")
+    mock_run.return_value = Mock(stdout="Europe/London\n")
+    assert get_system_timezone() == "Europe/London"
+    mock_run.assert_called_once_with(
+        ["timedatectl", "show", "--property=Timezone", "--value"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def test_get_system_timezone_fails(mocker):
+    mock_run = mocker.patch("acoupi.system.datetime.subprocess.run")
+    mock_run.side_effect = subprocess.CalledProcessError(1, "timedatectl")
+    assert get_system_timezone() is None
+
+
+def test_set_system_timezone(mocker):
+    mock_run = mocker.patch("acoupi.system.datetime.subprocess.run")
+    assert set_system_timezone("Europe/London") is True
+    mock_run.assert_called_once_with(
+        ["sudo", "timedatectl", "set-timezone", "Europe/London"],
+        check=True,
+        capture_output=True,
+    )
+
+
+def test_set_system_timezone_invalid_tz(mocker):
+    mock_run = mocker.patch("acoupi.system.datetime.subprocess.run")
+    assert set_system_timezone("Invalid/Timezone") is False
+    mock_run.assert_not_called()
+
+
+def test_set_system_timezone_fails(mocker):
+    mock_run = mocker.patch("acoupi.system.datetime.subprocess.run")
+    mock_run.side_effect = subprocess.CalledProcessError(1, "sudo")
+    assert set_system_timezone("Europe/London") is False

--- a/tests/test_system/test_datetime.py
+++ b/tests/test_system/test_datetime.py
@@ -1,44 +1,44 @@
 import subprocess
 from unittest.mock import Mock
+from zoneinfo import ZoneInfo
 
 from acoupi.system.datetime import get_system_timezone, set_system_timezone
 
 
-def test_get_system_timezone(mocker):
-    mock_run = mocker.patch("acoupi.system.datetime.subprocess.run")
-    mock_run.return_value = Mock(stdout="Europe/London\n")
-    assert get_system_timezone() == "Europe/London"
-    mock_run.assert_called_once_with(
-        ["timedatectl", "show", "--property=Timezone", "--value"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
+class TestGetSystemTimezone:
+    def test_returns_timezone_info(self, mocker):
+        mock_run = mocker.patch("acoupi.system.datetime.subprocess.run")
+        mock_run.return_value = Mock(stdout="Europe/London\n")
+        assert get_system_timezone() == ZoneInfo("Europe/London")
+        mock_run.assert_called_once_with(
+            ["timedatectl", "show", "--property=Timezone", "--value"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    def test_returns_none_when_command_fails(self, mocker):
+        mock_run = mocker.patch("acoupi.system.datetime.subprocess.run")
+        mock_run.side_effect = subprocess.CalledProcessError(1, "timedatectl")
+        assert get_system_timezone() is None
 
 
-def test_get_system_timezone_fails(mocker):
-    mock_run = mocker.patch("acoupi.system.datetime.subprocess.run")
-    mock_run.side_effect = subprocess.CalledProcessError(1, "timedatectl")
-    assert get_system_timezone() is None
+class TestSetSystemTimezone:
+    def test_successfully_updates_system_timezone(self, mocker):
+        mock_run = mocker.patch("acoupi.system.datetime.subprocess.run")
+        assert set_system_timezone("Europe/London") is True
+        mock_run.assert_called_once_with(
+            ["sudo", "timedatectl", "set-timezone", "Europe/London"],
+            check=True,
+            capture_output=True,
+        )
 
+    def test_returns_false_when_timezone_is_invalid(self, mocker):
+        mock_run = mocker.patch("acoupi.system.datetime.subprocess.run")
+        assert set_system_timezone("Invalid/Timezone") is False
+        mock_run.assert_not_called()
 
-def test_set_system_timezone(mocker):
-    mock_run = mocker.patch("acoupi.system.datetime.subprocess.run")
-    assert set_system_timezone("Europe/London") is True
-    mock_run.assert_called_once_with(
-        ["sudo", "timedatectl", "set-timezone", "Europe/London"],
-        check=True,
-        capture_output=True,
-    )
-
-
-def test_set_system_timezone_invalid_tz(mocker):
-    mock_run = mocker.patch("acoupi.system.datetime.subprocess.run")
-    assert set_system_timezone("Invalid/Timezone") is False
-    mock_run.assert_not_called()
-
-
-def test_set_system_timezone_fails(mocker):
-    mock_run = mocker.patch("acoupi.system.datetime.subprocess.run")
-    mock_run.side_effect = subprocess.CalledProcessError(1, "sudo")
-    assert set_system_timezone("Europe/London") is False
+    def test_returns_false_when_command_fails(self, mocker):
+        mock_run = mocker.patch("acoupi.system.datetime.subprocess.run")
+        mock_run.side_effect = subprocess.CalledProcessError(1, "sudo")
+        assert set_system_timezone("Europe/London") is False

--- a/tests/test_tasks/test_heartbeat_task.py
+++ b/tests/test_tasks/test_heartbeat_task.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 from unittest.mock import Mock
 
 import pytest
@@ -11,7 +12,7 @@ from acoupi.tasks import generate_heartbeat_task
 def test_heartbeat_task_sends_message(patched_now):
     messenger = Mock()
 
-    now = datetime.datetime(2024, 1, 1)
+    now = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
     patched_now(now)
     device_id = get_device_id()
 
@@ -27,7 +28,8 @@ def test_heartbeat_task_sends_message(patched_now):
     assert isinstance(message, data.Message)
     assert isinstance(message.content, str)
     assert device_id in message.content
-    assert now.isoformat() in message.content
+    payload = json.loads(message.content)
+    assert payload["sent_on"] == "2024-01-01T00:00:00Z"
 
 
 def test_heartbeat_task_send_message_with_all_messengers():

--- a/tests/test_tasks/test_management_task.py
+++ b/tests/test_tasks/test_management_task.py
@@ -1,6 +1,5 @@
 """Test suite for the file management task generator."""
 
-import datetime
 from pathlib import Path
 from typing import List, Optional, Sequence
 

--- a/tests/test_tasks/test_management_task.py
+++ b/tests/test_tasks/test_management_task.py
@@ -87,7 +87,7 @@ def recording(
         duration=1,
         samplerate=256000,
         audio_channels=1,
-        created_on=datetime.datetime.now(),
+        created_on=data.utc_now(),
         deployment=deployment,
     )
 
@@ -187,7 +187,7 @@ def test_file_management_ignores_files_without_path(
         path=None,
         duration=1,
         samplerate=256000,
-        created_on=datetime.datetime.now(),
+        created_on=data.utc_now(),
         deployment=deployment,
     )
     store.store_recording(recording)
@@ -241,7 +241,7 @@ def test_file_management_preserves_existing_guano_metadata(
         duration=1,
         samplerate=16000,
         audio_channels=1,
-        created_on=datetime.datetime.now(),
+        created_on=data.utc_now(),
         deployment=deployment,
     )
     store.store_recording(recording)

--- a/tests/test_tasks/test_recording_task.py
+++ b/tests/test_tasks/test_recording_task.py
@@ -23,7 +23,7 @@ class DummyRecorder(AudioRecorder):
     def __init__(
         self,
         path: Path,
-        created_on: datetime.datetime,
+        created_on: data.AwareDatetime,
         samplerate: int = 16000,
         duration: float = 1.0,
     ):
@@ -58,9 +58,13 @@ def test_recording_task_writes_guano_metadata_with_location(
         name="field-site-a",
         latitude=51.5072,
         longitude=-0.1276,
-        started_on=datetime.datetime(2024, 1, 1, 0, 0, 0),
+        started_on=datetime.datetime(
+            2024, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
+        ),
     )
-    created_on = datetime.datetime(2024, 8, 4, 5, 6, 7)
+    created_on = datetime.datetime(
+        2024, 8, 4, 5, 6, 7, tzinfo=datetime.timezone.utc
+    )
 
     store = SqliteStore(tmp_path / "metadata.db")
     store.store_deployment(deployment)
@@ -99,9 +103,13 @@ def test_recording_task_writes_guano_metadata_without_location(
 
     deployment = data.Deployment(
         name="field-site-b",
-        started_on=datetime.datetime(2024, 1, 1, 0, 0, 0),
+        started_on=datetime.datetime(
+            2024, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc
+        ),
     )
-    created_on = datetime.datetime(2024, 8, 4, 5, 6, 7)
+    created_on = datetime.datetime(
+        2024, 8, 4, 5, 6, 7, tzinfo=datetime.timezone.utc
+    )
 
     store = SqliteStore(tmp_path / "metadata.db")
     store.store_deployment(deployment)

--- a/uv.lock
+++ b/uv.lock
@@ -20,7 +20,6 @@ dependencies = [
     { name = "pydantic-extra-types" },
     { name = "pydantic-settings" },
     { name = "pygments" },
-    { name = "pytz" },
     { name = "pyyaml" },
     { name = "requests" },
 ]
@@ -59,7 +58,6 @@ requires-dist = [
     { name = "pydantic-extra-types", specifier = ">=2.9.0" },
     { name = "pydantic-settings", specifier = ">=2.0.3" },
     { name = "pygments", specifier = ">=2.18.0" },
-    { name = "pytz", specifier = ">=2023.3.post1" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.31.0" },
 ]


### PR DESCRIPTION
This PR implements timezone-aware datetimes throughout the codebase and migrates from the deprecated `pytz` library to the standard library's `zoneinfo`.

### Key Changes:
- **Timezone-aware Datetimes**:
  - Replaced `datetime.datetime` with `pydantic.AwareDatetime` in all core data models (`Deployment`, `Recording`, `ModelOutput`, etc.).
  - Introduced `acoupi.data.utc_now()` as the standard way to generate UTC-aware datetimes.
  - Updated SQLite storage layers to preserve timezone awareness and normalize legacy naive datetimes to UTC on read.
- **`zoneinfo` Migration**:
  - Removed `pytz` dependency.
  - Updated `connected` and `default` programs to use `zoneinfo.ZoneInfo`.
- **System Datetime Utilities**:
  - Added `acoupi.system.datetime` with `get_system_timezone()` and `set_system_timezone()` using `timedatectl`.
  - Added comprehensive unit tests for the new system utilities.
- **Test Suite Updates**:
  - Updated all test fixtures and assertions to use aware datetimes.
  - Fixed `patched_now` helper to handle timezone-aware calls.
  - Ensured deterministic ordering for predicted tags in SQLite queries to maintain stable test assertions.