### PR TITLE
feat: add aligned Celery schedules

### DIFF
--- a/docs/howtoguide/programs.md
+++ b/docs/howtoguide/programs.md
@@ -174,6 +174,35 @@ from celery.schedules import crontab
         )
 ```
 
+- **Aligned intervals**
+
+If you need second-level intervals that line up with the wall clock, use
+[`aligned_schedule`][acoupi.tasks.aligned_schedule]. This is useful when you
+want a task to run at exact second boundaries, such as ``:00, :10, :20`` of
+every minute.
+
+```python
+import datetime
+
+from acoupi.tasks import aligned_schedule
+
+...
+
+    def setup(self, config):
+        ...
+
+        self.add_task(
+            my_custom_task,
+            schedule=aligned_schedule(
+                run_every=datetime.timedelta(seconds=10),
+                offset_seconds=0,
+            ),
+        )
+```
+
+Set ``offset_seconds=5`` if you want the task to run at ``:05, :15, :25`` and
+so on.
+
 #### Task dependencies
 
 Often, tasks within a program need to execute in a specific order or depend on the output of other tasks.

--- a/src/acoupi/data.py
+++ b/src/acoupi/data.py
@@ -93,10 +93,12 @@ class Deployment(BaseModel):
 
     @field_validator("started_on", "ended_on", mode="before")
     def add_missing_timezone(cls, v):
-        if v is None:
-            return v
-
         if isinstance(v, str):
+            # Leave timezone-aware strings to Pydantic so parsing remains
+            # consistent across Python versions, especially for trailing ``Z``.
+            if v.endswith("Z") or "+" in v[10:] or "-" in v[10:]:
+                return v
+
             v = datetime.datetime.fromisoformat(v)
 
         if isinstance(v, datetime.datetime) and v.tzinfo is None:

--- a/src/acoupi/data.py
+++ b/src/acoupi/data.py
@@ -99,10 +99,7 @@ class Deployment(BaseModel):
         if isinstance(v, str):
             v = datetime.datetime.fromisoformat(v)
 
-        if not isinstance(v, datetime.datetime):
-            raise ValueError("Should be datetime")
-
-        if v.tzinfo is None:
+        if isinstance(v, datetime.datetime) and v.tzinfo is None:
             v = v.replace(tzinfo=datetime.timezone.utc)
 
         return v

--- a/src/acoupi/data.py
+++ b/src/acoupi/data.py
@@ -91,6 +91,22 @@ class Deployment(BaseModel):
     ended_on: Optional[AwareDatetime] = None
     """The datetime when the deployment ended."""
 
+    @field_validator("started_on", "ended_on", mode="before")
+    def add_missing_timezone(cls, v):
+        if v is None:
+            return v
+
+        if isinstance(v, str):
+            v = datetime.datetime.fromisoformat(v)
+
+        if not isinstance(v, datetime.datetime):
+            raise ValueError("Should be datetime")
+
+        if v.tzinfo is None:
+            v = v.replace(tzinfo=datetime.timezone.utc)
+
+        return v
+
     @field_validator("latitude")
     def validate_latitude(cls, value):
         """Validate that the latitude are within range."""

--- a/src/acoupi/programs/core/base.py
+++ b/src/acoupi/programs/core/base.py
@@ -8,7 +8,7 @@ from functools import wraps
 from typing import Generic, List, Optional, Protocol, Type, TypeVar, Union
 
 from celery import Celery, Task, group
-from celery.schedules import crontab
+from celery.schedules import BaseSchedule, crontab
 from celery.utils.log import get_task_logger
 from pydantic import BaseModel
 
@@ -139,7 +139,13 @@ class AcoupiProgram(ABC, Generic[ProgramConfig]):
         self,
         function: NamedCallable[[], Optional[B]],
         callbacks: Optional[List[NamedCallable[[Optional[B]], None]]] = None,
-        schedule: Union[int, datetime.timedelta, crontab, None] = None,
+        schedule: Union[
+            int,
+            datetime.timedelta,
+            crontab,
+            BaseSchedule,
+            None,
+        ] = None,
         queue: Optional[str] = None,
         callback_queue: Optional[str] = None,
         name: Optional[str] = None,
@@ -154,7 +160,8 @@ class AcoupiProgram(ABC, Generic[ProgramConfig]):
             Optional list of callables to run after the task completes,
             receiving the task's return value as their argument.
         schedule :
-            How often to run the task (timedelta, seconds, or crontab).
+            How often to run the task (timedelta, seconds, crontab, or a
+            custom Celery schedule).
         queue :
             Name of the queue the task itself should be routed to. Must be
             declared in the program's ``worker_config``.

--- a/src/acoupi/system/constants.py
+++ b/src/acoupi/system/constants.py
@@ -93,7 +93,7 @@ class CeleryConfig(BaseModel):
 
     task_acks_late: bool = True
     """Whether to acknowledge tasks after they have been executed. 
-    
+
     True means that tasks are acknowledged after they have been executed, 
     not right before.
     """
@@ -122,4 +122,11 @@ class CeleryConfig(BaseModel):
 
     If you have tasks that are expected to run longer than this limit,
     you should increase this value or specify the time limit directly.
+    """
+
+    beat_max_loop_interval: int = 1
+    """Maximum number of seconds Celery beat sleeps between checks.
+
+    Keeping this low allows beat to dispatch second-aligned periodic tasks with
+    predictable timing.
     """

--- a/src/acoupi/tasks/__init__.py
+++ b/src/acoupi/tasks/__init__.py
@@ -22,6 +22,7 @@ from acoupi.tasks.heartbeat import generate_heartbeat_task
 from acoupi.tasks.management import generate_file_management_task
 from acoupi.tasks.messaging import generate_send_messages_task
 from acoupi.tasks.recording import generate_recording_task
+from acoupi.tasks.schedules import aligned_schedule
 from acoupi.tasks.summary import generate_summariser_task
 
 __all__ = [
@@ -31,4 +32,5 @@ __all__ = [
     "generate_send_messages_task",
     "generate_summariser_task",
     "generate_heartbeat_task",
+    "aligned_schedule",
 ]

--- a/src/acoupi/tasks/schedules.py
+++ b/src/acoupi/tasks/schedules.py
@@ -25,6 +25,22 @@ class aligned_schedule(BaseSchedule):
         nowfun=None,
         app=None,
     ):
+        """Initialise a wall-clock-aligned interval schedule.
+
+        Parameters
+        ----------
+        run_every : datetime.timedelta
+            Interval between valid schedule slots.
+        offset_seconds : int, optional
+            Offset applied within each interval. With ``run_every=10`` seconds
+            and ``offset_seconds=5``, the schedule runs at ``:05, :15, :25``
+            and so on. Must be non-negative and smaller than ``run_every``.
+        nowfun : callable, optional
+            Override used by Celery to obtain the current time. Primarily
+            useful for testing.
+        app : celery.Celery, optional
+            Celery application instance passed through to ``BaseSchedule``.
+        """
         self.run_every = run_every
         self.offset_seconds = offset_seconds
         super().__init__(nowfun=nowfun, app=app)

--- a/src/acoupi/tasks/schedules.py
+++ b/src/acoupi/tasks/schedules.py
@@ -1,0 +1,73 @@
+"""Custom Celery schedules used by Acoupi tasks."""
+
+from __future__ import annotations
+
+import datetime
+
+from celery.schedules import BaseSchedule, schedstate
+
+__all__ = ["aligned_schedule"]
+
+
+class aligned_schedule(BaseSchedule):
+    """Run tasks on absolute clock boundaries at a fixed interval.
+
+    This behaves like an interval schedule, but aligns executions to wall clock
+    boundaries instead of anchoring them to the previous run time. For example,
+    a ``run_every`` of 10 seconds with ``offset_seconds=0`` will run at seconds
+    ``0, 10, 20, 30, 40, 50`` of every minute.
+    """
+
+    def __init__(
+        self,
+        run_every: datetime.timedelta,
+        offset_seconds: int = 0,
+        nowfun=None,
+        app=None,
+    ):
+        self.run_every = run_every
+        self.offset_seconds = offset_seconds
+        super().__init__(nowfun=nowfun, app=app)
+
+        interval_seconds = self.seconds
+        if interval_seconds <= 0:
+            raise ValueError("run_every must be greater than zero")
+
+        if offset_seconds < 0:
+            raise ValueError("offset_seconds must be non-negative")
+
+        if offset_seconds >= interval_seconds:
+            raise ValueError("offset_seconds must be smaller than run_every")
+
+    def is_due(self, last_run_at: datetime.datetime):
+        last_run_at = self.maybe_make_aware(last_run_at)
+        now = self.maybe_make_aware(self.now())
+
+        current_slot = self._slot_index(now)
+        last_slot = self._slot_index(last_run_at)
+
+        if current_slot > last_slot:
+            return schedstate(is_due=True, next=self.seconds)
+
+        return schedstate(
+            is_due=False, next=self._seconds_until_next_slot(now)
+        )
+
+    def __repr__(self) -> str:
+        return (
+            "<clock-aligned schedule: "
+            f"every {self.run_every}, offset {self.offset_seconds}s>"
+        )
+
+    @property
+    def seconds(self) -> float:
+        return self.run_every.total_seconds()
+
+    def _slot_index(self, moment: datetime.datetime) -> int:
+        return int((moment.timestamp() - self.offset_seconds) // self.seconds)
+
+    def _seconds_until_next_slot(self, now: datetime.datetime) -> float:
+        next_slot = (
+            self._slot_index(now) + 1
+        ) * self.seconds + self.offset_seconds
+        return max(next_slot - now.timestamp(), 0)

--- a/tests/test_system/test_constants.py
+++ b/tests/test_system/test_constants.py
@@ -1,0 +1,7 @@
+from acoupi.system.constants import CeleryConfig
+
+
+def test_celery_config_defaults_include_short_beat_loop_interval():
+    config = CeleryConfig().model_dump()
+
+    assert config["beat_max_loop_interval"] == 1

--- a/tests/test_system/test_deployments.py
+++ b/tests/test_system/test_deployments.py
@@ -121,3 +121,13 @@ def test_loads_legacy_deployment_timestamps_as_utc():
     assert deployment.ended_on == datetime.datetime(
         2024, 1, 1, 13, 0, 0, tzinfo=datetime.timezone.utc
     )
+
+
+def test_loads_z_suffixed_deployment_timestamps_as_utc():
+    deployment = data.Deployment.model_validate_json(
+        '{"name":"current","started_on":"2024-01-01T12:00:00Z"}'
+    )
+
+    assert deployment.started_on == datetime.datetime(
+        2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc
+    )

--- a/tests/test_system/test_deployments.py
+++ b/tests/test_system/test_deployments.py
@@ -1,5 +1,7 @@
 """Test suite for system deployment functions."""
 
+import datetime
+
 import pytest
 
 from acoupi import data
@@ -102,3 +104,20 @@ def test_get_current_deployment_fails_if_ended(settings: Settings):
     deployments.end_deployment(settings)
     with pytest.raises(exceptions.DeploymentError):
         deployments.get_current_deployment(settings)
+
+
+def test_loads_legacy_deployment_timestamps_as_utc():
+    deployment = data.Deployment.model_validate(
+        {
+            "name": "legacy",
+            "started_on": "2024-01-01T12:00:00",
+            "ended_on": "2024-01-01T13:00:00",
+        }
+    )
+
+    assert deployment.started_on == datetime.datetime(
+        2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc
+    )
+    assert deployment.ended_on == datetime.datetime(
+        2024, 1, 1, 13, 0, 0, tzinfo=datetime.timezone.utc
+    )

--- a/tests/test_tasks/test_schedules.py
+++ b/tests/test_tasks/test_schedules.py
@@ -1,0 +1,76 @@
+import datetime
+
+import pytest
+
+from acoupi.tasks.schedules import aligned_schedule
+
+UTC = datetime.timezone.utc
+
+
+def test_aligned_schedule_is_due_on_interval_boundary():
+    schedule = aligned_schedule(
+        run_every=datetime.timedelta(seconds=10),
+        nowfun=lambda: datetime.datetime(2024, 1, 1, 12, 0, 20, tzinfo=UTC),
+    )
+
+    state = schedule.is_due(
+        last_run_at=datetime.datetime(2024, 1, 1, 12, 0, 19, tzinfo=UTC)
+    )
+
+    assert state.is_due is True
+    assert state.next == 10
+
+
+def test_aligned_schedule_waits_until_next_boundary():
+    schedule = aligned_schedule(
+        run_every=datetime.timedelta(seconds=10),
+        nowfun=lambda: datetime.datetime(2024, 1, 1, 12, 0, 12, tzinfo=UTC),
+    )
+
+    state = schedule.is_due(
+        last_run_at=datetime.datetime(2024, 1, 1, 12, 0, 10, tzinfo=UTC)
+    )
+
+    assert state.is_due is False
+    assert state.next == pytest.approx(8)
+
+
+def test_aligned_schedule_honours_offset_seconds():
+    schedule = aligned_schedule(
+        run_every=datetime.timedelta(seconds=10),
+        offset_seconds=5,
+        nowfun=lambda: datetime.datetime(2024, 1, 1, 12, 0, 25, tzinfo=UTC),
+    )
+
+    state = schedule.is_due(
+        last_run_at=datetime.datetime(2024, 1, 1, 12, 0, 24, tzinfo=UTC)
+    )
+
+    assert state.is_due is True
+    assert state.next == 10
+
+
+def test_aligned_schedule_does_not_repeat_in_same_slot():
+    schedule = aligned_schedule(
+        run_every=datetime.timedelta(seconds=10),
+        nowfun=lambda: datetime.datetime(
+            2024, 1, 1, 12, 0, 20, 500000, tzinfo=UTC
+        ),
+    )
+
+    state = schedule.is_due(
+        last_run_at=datetime.datetime(2024, 1, 1, 12, 0, 20, tzinfo=UTC)
+    )
+
+    assert state.is_due is False
+    assert state.next == pytest.approx(9.5)
+
+
+def test_aligned_schedule_rejects_invalid_offset():
+    with pytest.raises(
+        ValueError, match="offset_seconds must be smaller than run_every"
+    ):
+        aligned_schedule(
+            run_every=datetime.timedelta(seconds=10),
+            offset_seconds=10,
+        )


### PR DESCRIPTION
## Summary

This PR adds support for wall-clock-aligned periodic Celery schedules in Acoupi.

Celery’s built-in options did not cover the scheduling behavior we needed:

- `crontab` gives predictable wall-clock timing, but only at minute resolution
- `schedule(..., relative=True)` does not align sub-minute intervals to exact second boundaries and does not support offsets

To address that, this PR introduces a custom schedule that supports patterns like:

- every 10 seconds at `:00, :10, :20, :30, :40, :50`
- every 10 seconds with an offset, e.g. `:05, :15, :25, :35, :45, :55`

## Changes

- add `acoupi.tasks.aligned_schedule`
- allow `AcoupiProgram.add_task()` to accept custom Celery `BaseSchedule` instances
- set `beat_max_loop_interval=1` in `CeleryConfig` so beat checks often enough for second-level alignment
- add tests for aligned schedule behavior
- add compatibility support for legacy deployment files with naive timestamps
- add regression coverage for legacy deployment timestamp parsing
- document `aligned_schedule` in the programs how-to guide and source docstrings

## Why

This gives Acoupi predictable second-level scheduling without relying on minute-only cron expressions.

Example:

```python
from datetime import timedelta
from acoupi.tasks import aligned_schedule

self.add_task(
    my_task,
    schedule=aligned_schedule(
        run_every=timedelta(seconds=10),
        offset_seconds=0,
    ),
)
```

## Notes

- `aligned_schedule` aligns dispatch to wall-clock boundaries rather than anchoring to `last_run_at + run_every`
- `offset_seconds` must be smaller than `run_every`
- this is still Celery beat scheduling, so dispatch is predictable, but execution remains subject to normal broker/worker latency

## Testing

Ran:

- `pytest tests/test_tasks/test_schedules.py`
- `pytest tests/test_system/test_constants.py tests/test_system/test_lifecycle.py`
- `pytest tests/test_system/test_deployments.py`
