### PR TITLE
Use device-independent serial for GUANO metadata

### DIFF
--- a/src/acoupi/tasks/recording.py
+++ b/src/acoupi/tasks/recording.py
@@ -11,19 +11,14 @@ The recording process contains the following steps:
 """
 
 import logging
-import sys
+from importlib.metadata import version
 from typing import Callable, List, Optional, TypeVar
 
 from guano import GuanoFile
 
 from acoupi import data
 from acoupi.components import types
-from acoupi.devices import get_rpi_serial_number
-
-if sys.version_info < (3, 10):
-    from importlib_metadata import version
-else:
-    from importlib.metadata import version
+from acoupi.devices import get_device_id
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -122,7 +117,7 @@ def add_guano_metadata(recording: data.Recording) -> None:
     g["Acoupi|Deployment Name"] = recording.deployment.name
     g["Firmware Version"] = version("acoupi")
     g["Make"] = "acoupi"
-    g["Serial"] = get_rpi_serial_number()
+    g["Serial"] = get_device_id()
     g["Samplerate"] = recording.samplerate
 
     if recording.time_expansion != 1:

--- a/tests/test_components/test_audio_recording/test_pyaudio_recorder.py
+++ b/tests/test_components/test_audio_recording/test_pyaudio_recorder.py
@@ -224,7 +224,7 @@ def test_time_expansion_is_saved_in_guano_metadata(
     tmp_path: Path, deployment: data.Deployment, mocker
 ):
     mocker.patch(
-        "acoupi.tasks.recording.get_rpi_serial_number",
+        "acoupi.tasks.recording.get_device_id",
         return_value="1234567890ABCDEF",
     )
 

--- a/tests/test_tasks/test_recording_task.py
+++ b/tests/test_tasks/test_recording_task.py
@@ -44,7 +44,7 @@ def test_recording_task_writes_guano_metadata_with_location(
     mocker,
 ):
     mocker.patch(
-        "acoupi.tasks.recording.get_rpi_serial_number",
+        "acoupi.tasks.recording.get_device_id",
         return_value="1234567890ABCDEF",
     )
 
@@ -91,7 +91,7 @@ def test_recording_task_writes_guano_metadata_without_location(
     mocker,
 ):
     mocker.patch(
-        "acoupi.tasks.recording.get_rpi_serial_number",
+        "acoupi.tasks.recording.get_device_id",
         return_value="1234567890ABCDEF",
     )
 


### PR DESCRIPTION
This fixes GUANO metadata generation on non-Raspberry Pi devices.

Previously, the `Serial` field used `get_rpi_serial_number()`, which can fail on devices that are not RPis. This PR switches to `get_device_id()`, which is intended to be device-independent and is the correct source for serial metadata.