### PR TITLE
fix: skip empty summary messages

### DIFF
--- a/src/acoupi/components/types.py
+++ b/src/acoupi/components/types.py
@@ -468,7 +468,7 @@ class Summariser(ABC):
     def build_summary(
         self,
         now: datetime.datetime,
-    ) -> data.Message:
+    ) -> data.Message | None:
         """Build a summary.
 
         Parameters
@@ -478,9 +478,10 @@ class Summariser(ABC):
 
         Returns
         -------
-        data.Message
+        data.Message | None
             The summary as a data.Message object. Built-in summarisers emit
-            JSON text, but custom summarisers may emit raw bytes.
+            JSON text, but custom summarisers may emit raw bytes. Return
+            ``None`` when there is no summary to emit for the requested time.
         """
 
 

--- a/src/acoupi/tasks/summary.py
+++ b/src/acoupi/tasks/summary.py
@@ -49,17 +49,27 @@ def generate_summariser_task(
         - Store the summary message in the message store.
         - See [components.stores][acoupi.components.stores] for implementation
         of [types.Store][acoupi.components.types.Store].
+
+    If a summariser returns ``None`` from ``build_summary``, the task treats
+    that as "no summary available" and skips storing any message for that
+    summariser.
     """
 
     def summary_task() -> None:
         """Create a summary message."""
         now = utc_now()
+        logger.info(
+            "Starting summary generation for %d summariser(s).",
+            len(summarisers),
+        )
 
         for summariser in summarisers:
-            logger.info(f"SUMMARISER: {summariser}")
             try:
+                logger.debug(
+                    "Building summary message with summariser %s.",
+                    summariser,
+                )
                 summary_message = summariser.build_summary(now)
-                logger.info(f"SUMMARY MESSAGE: {summary_message}")
             except Exception as e:
                 logger.error(
                     "Error building summary message for summariser %s: %s",
@@ -68,9 +78,22 @@ def generate_summariser_task(
                 )
                 continue
 
+            if summary_message is None:
+                logger.debug(
+                    "Summariser %s returned no summary message. Skipping.",
+                    summariser,
+                )
+                continue
+
             # Store Message
+            logger.info(
+                "Storing summary message from summariser %s.",
+                summariser,
+            )
             message_store.store_message(summary_message)
-            logger.debug(f"Summary Message Stored: {summary_message}")
-            logger.debug("Message stored %s", summary_message)
+            logger.debug(
+                "Stored summary message from summariser %s.",
+                summariser,
+            )
 
     return summary_task

--- a/tests/test_tasks/test_summary_task.py
+++ b/tests/test_tasks/test_summary_task.py
@@ -1,0 +1,37 @@
+from unittest.mock import Mock
+
+from acoupi import data
+from acoupi.tasks import generate_summariser_task
+
+
+def test_summary_task_skips_storing_none_messages():
+    summariser = Mock()
+    summariser.build_summary.return_value = None
+    message_store = Mock()
+
+    task = generate_summariser_task(
+        summarisers=[summariser],
+        message_store=message_store,
+    )
+
+    task()
+
+    summariser.build_summary.assert_called_once()
+    message_store.store_message.assert_not_called()
+
+
+def test_summary_task_stores_summary_messages():
+    summary_message = data.Message(content="summary")
+    summariser = Mock()
+    summariser.build_summary.return_value = summary_message
+    message_store = Mock()
+
+    task = generate_summariser_task(
+        summarisers=[summariser],
+        message_store=message_store,
+    )
+
+    task()
+
+    summariser.build_summary.assert_called_once()
+    message_store.store_message.assert_called_once_with(summary_message)


### PR DESCRIPTION
## Summary
This PR updates the summary task so that summarisers can explicitly return `None` when there is no summary to emit, without causing an empty message to be stored.

## Changes
- Update `generate_summariser_task()` to skip storing messages when `summariser.build_summary()` returns `None`
- Document the new behavior in the `generate_summariser_task()` docstring
- Clarify the `Summariser.build_summary()` contract to document `None` as a valid return value when no summary is available
- Add task-level tests covering:
  - `None` summaries are not stored
  - non-`None` summaries are stored

## Motivation
Some summarisers may legitimately have nothing to report for a given interval. In those cases, returning `None` is now treated as an intentional "no summary available" result rather than something that should be stored.

## Testing
- `pytest tests/test_tasks/test_summary_task.py`
