### PR TITLE
Fix Python 3.10+ UnionType config parsing and PipeWire range dictionary handling

### DIFF
--- a/src/acoupi/devices/audio/pipewire.py
+++ b/src/acoupi/devices/audio/pipewire.py
@@ -61,16 +61,44 @@ def get_input_devices() -> list[DeviceInfo]:
     ]
 
 
+def _extract_rate(rate_field) -> list[int]:
+    if isinstance(rate_field, int):
+        return [rate_field]
+    if isinstance(rate_field, list):
+        return [r for r in rate_field if isinstance(r, int)]
+    if isinstance(rate_field, dict):
+        default = rate_field.get("default")
+        min_rate = rate_field.get("min")
+        max_rate = rate_field.get("max")
+        rates = []
+        if isinstance(default, int):
+            rates.append(default)
+        if isinstance(min_rate, int) and isinstance(max_rate, int):
+            for r in [16000, 32000, 44100, 48000, 96000, 192000]:
+                if min_rate <= r <= max_rate:
+                    rates.append(r)
+        if not rates:
+            if isinstance(min_rate, int):
+                rates.append(min_rate)
+            if isinstance(max_rate, int):
+                rates.append(max_rate)
+        return rates
+    return [48000]
+
+
 def _parse_pw_info(pw_info: dict) -> DeviceInfo:
     """Convert raw ``pw-dump`` node information into ``DeviceInfo``."""
     props = pw_info["props"]
     formats = pw_info["params"]["EnumFormat"]
     default_format = formats[0]
+    samplerates = set()
+    for f in formats:
+        samplerates.update(_extract_rate(f.get("rate", 48_000)))
     return DeviceInfo(
         name=props["node.name"],
         description=props["node.description"],
         max_input_channels=default_format["channels"],
-        samplerates=list({format.get("rate", 48_000) for format in formats}),
+        samplerates=list(samplerates),
     )
 
 

--- a/src/acoupi/system/config/parsers.py
+++ b/src/acoupi/system/config/parsers.py
@@ -459,7 +459,8 @@ def get_field_dtype(field: FieldInfo) -> type:
 
     # Check for optional fields and remove the
     # typing.Optional if present
-    if origin == Union:
+    import types
+    if origin in (Union, getattr(types, "UnionType", None)):
         nested = get_args(annotation)[0]
         return nested
 


### PR DESCRIPTION
## Description
This Pull Request resolves two compatibility issues encountered when setting up `acoupi` on modern environments (e.g., Python 3.12+ on Debian Trixie / ARM64 - I am experimenting on Arduino UNO Q):

1. **TypeError during PipeWire device discovery:**
   On some microphones and environments, `pw-dump` returns supported sample rates as a range dictionary (e.g., `{"min": 8000, "max": 192000}`) rather than a flat integer. The existing logic tried to add this unhashable dictionary directly to a set in `_parse_pw_info`, raising a `TypeError: unhashable type: 'dict'`.
   * **Fix:** Introduced an `_extract_rate` helper to check the format of the `rate` field (handling integers, lists, and dict ranges) and flatten them safely into supported sample rates.

2. **NotImplementedError during Pydantic configuration setup:**
   Under Python 3.10+, union types like `Path | None` resolve to `types.UnionType` rather than `typing.Union`. The config parser's `get_field_dtype` only checked for `typing.Union`, causing it to miss optional fields (like `species_list_file` in `BirdNETConfig`) and crash with `NotImplementedError: Cannot parse argument for field...`.
   * **Fix:** Updated the type resolution logic in `get_field_dtype` to support both `typing.Union` and modern `types.UnionType`.

---

## Changes Made
* `src/acoupi/devices/audio/pipewire.py`: Added `_extract_rate` helper and modified `_parse_pw_info` to parse complex sample rate formats returned by `pw-dump`.
* `src/acoupi/system/config/parsers.py`: Modified `get_field_dtype` to correctly resolve `types.UnionType` (introduced via `A | B` syntax in PEP 604).

---

## Verification & Testing
* **TypeError:** Tested setup using an AudioMoth USB Microphone where PipeWire returned range definitions. Confirmed it resolved correctly and selected the default rates.
* **NotImplementedError:** Confirmed the setup wizard successfully prompts for optional fields (like `species_list_file` mapped as `Path | None`) instead of failing with a `NotImplementedError` on Python 3.12+.