### PR TITLE
feat(summary): allow summarisers to emit multiple messages

### DIFF
--- a/docs/explanation/components.md
+++ b/docs/explanation/components.md
@@ -100,4 +100,5 @@ Each component can be configured to operate in a specific way, and can be combin
 #### Summarisers
 
 The [types.Summariser][acoupi.components.types.Summariser] component is responsible for summarising information related to the deployment of acoupi, its recordings and detections.
-The class implement two subclasses `StatisticsDetectionsSummariser` and `ThresholdsDetectionsSummariser`.
+Depending on the implementation, a summariser may return no message, a single summary message, or multiple summary messages for the same time interval.
+The class implement two subclasses: [StatisticsDetectionsSummariser][acoupi.components.summariser.StatisticsDetectionsSummariser] and [ThresholdsDetectionsSummariser][acoupi.components.summariser.ThresholdsDetectionsSummariser].

--- a/docs/explanation/tasks.md
+++ b/docs/explanation/tasks.md
@@ -76,7 +76,7 @@ The task builds upon the acoupi components: `ProcessingFilter` to determine if a
     from typing import Optional
 
     from acoupi import components, data, tasks
-    
+
     from acoupi_batdetect2.model import BatDetect2
 
     recording_task = tasks.generate_detection_task(
@@ -109,8 +109,10 @@ This is useful when a recording should stay in temporary storage until other tas
 
 #### Summary
 
-The [Summary](../reference/tasks.md) task is responsible for generating summary messages to be sent to a remote server.
-It uses the `Summariser` component along with the `Messenger` component to define the communication protocol for sending these messages. 
+The [Summary][acoupi.tasks.summary.generate_summariser_task] task is responsible for generating summary messages to be sent to a remote server.
+It uses one or many user-provided [Summariser][acoupi.components.types.Summariser] components to build summary messages, then stores those messages for the [Messaging][acoupi.tasks.messaging.generate_send_messages_task] task to send independently.
+
+Each summariser may return no message, a single message, or multiple messages for a given summary interval. When multiple messages are returned, the summary task stores each one so they can be sent individually.
 
 The summary task is useful for providing aggregated information on detections over specific time periods such as hourly, daily, or weekly.
 

--- a/src/acoupi/components/summariser.py
+++ b/src/acoupi/components/summariser.py
@@ -1,7 +1,8 @@
 """Summariser for acoupi.
 
 Summarisers are responsible for summarising model outputs (i.e., detections).
-Summarisers output a summary of type data.Message. The StatisticsDetectionsSummariser
+Summarisers may output no summary, a single [data.Message][acoupi.data.Message], or multiple
+messages depending on the implementation. The StatisticsDetectionsSummariser
 summarises the detections by calculating the mean, min, max, and count of classifications
 probabilities for each species. The ThresholdsDetectionsSummariser summarises the detections
 by calculating the count and mean of classifications probabilities for each species
@@ -11,7 +12,7 @@ The message output by the Summarisers is then used by the Messenger to send the 
 to a remote server. Summarisers are implemented as classes that inherit from Summariser.
 Implemntation of the Summarisers should refer to the database, where the classifications
 probabilities are stored. The class should implement the build_summary method, which
-takes a datetime.datetime object and returns a message payload.
+takes a datetime.datetime object and returns no message, one [data.Message][acoupi.data.Message], or many messages.
 """
 
 import datetime

--- a/src/acoupi/components/types.py
+++ b/src/acoupi/components/types.py
@@ -468,7 +468,7 @@ class Summariser(ABC):
     def build_summary(
         self,
         now: datetime.datetime,
-    ) -> data.Message | None:
+    ) -> data.Message | list[data.Message] | None:
         """Build a summary.
 
         Parameters
@@ -478,10 +478,10 @@ class Summariser(ABC):
 
         Returns
         -------
-        data.Message | None
-            The summary as a data.Message object. Built-in summarisers emit
-            JSON text, but custom summarisers may emit raw bytes. Return
-            ``None`` when there is no summary to emit for the requested time.
+        data.Message | list[data.Message] | None
+            The summary as a single data.Message or a list of messages.
+            Return ``None`` when there is no summary to emit for the requested
+            time.
         """
 
 

--- a/src/acoupi/tasks/summary.py
+++ b/src/acoupi/tasks/summary.py
@@ -40,8 +40,8 @@ def generate_summariser_task(
     -----
     The summary process calls the following methods:
 
-    1. **summariser.build_summary(now)** -> data.Message
-        - Generate a summary message.
+    1. **summariser.build_summary(now)** -> data.Message | list[data.Message]
+        - Generate one or more summary messages.
         - See [components.summarisers][acoupi.components.summariser] for
         implementations of
         [types.Summariser][acoupi.components.types.Summariser].
@@ -52,7 +52,7 @@ def generate_summariser_task(
 
     If a summariser returns ``None`` from ``build_summary``, the task treats
     that as "no summary available" and skips storing any message for that
-    summariser.
+    summariser. If it returns a list of messages, the task stores each one.
     """
 
     def summary_task() -> None:
@@ -69,7 +69,7 @@ def generate_summariser_task(
                     "Building summary message with summariser %s.",
                     summariser,
                 )
-                summary_message = summariser.build_summary(now)
+                summary_messages = summariser.build_summary(now)
             except Exception as e:
                 logger.error(
                     "Error building summary message for summariser %s: %s",
@@ -78,22 +78,26 @@ def generate_summariser_task(
                 )
                 continue
 
-            if summary_message is None:
+            if summary_messages is None:
                 logger.debug(
                     "Summariser %s returned no summary message. Skipping.",
                     summariser,
                 )
                 continue
 
-            # Store Message
+            if not isinstance(summary_messages, list):
+                summary_messages = [summary_messages]
+
             logger.info(
-                "Storing summary message from summariser %s.",
+                "Storing %d summary message(s) from summariser %s.",
+                len(summary_messages),
                 summariser,
             )
-            message_store.store_message(summary_message)
-            logger.debug(
-                "Stored summary message from summariser %s.",
-                summariser,
-            )
+            for summary_message in summary_messages:
+                message_store.store_message(summary_message)
+                logger.debug(
+                    "Stored summary message from summariser %s.",
+                    summariser,
+                )
 
     return summary_task

--- a/tests/test_tasks/test_summary_task.py
+++ b/tests/test_tasks/test_summary_task.py
@@ -35,3 +35,25 @@ def test_summary_task_stores_summary_messages():
 
     summariser.build_summary.assert_called_once()
     message_store.store_message.assert_called_once_with(summary_message)
+
+
+def test_summary_task_stores_multiple_summary_messages():
+    summary_messages = [
+        data.Message(content="summary-1"),
+        data.Message(content="summary-2"),
+    ]
+    summariser = Mock()
+    summariser.build_summary.return_value = summary_messages
+    message_store = Mock()
+
+    task = generate_summariser_task(
+        summarisers=[summariser],
+        message_store=message_store,
+    )
+
+    task()
+
+    summariser.build_summary.assert_called_once()
+    assert message_store.store_message.call_count == 2
+    message_store.store_message.assert_any_call(summary_messages[0])
+    message_store.store_message.assert_any_call(summary_messages[1])


### PR DESCRIPTION
## Summary

This PR updates the summary pipeline so a `Summariser` can return:

- `None`
- a single `data.Message`
- a list of `data.Message` objects

The summary task now stores each returned message individually, while preserving the existing behavior for `None` and single-message returns.

## Changes

- widen `Summariser.build_summary(...)` to return `data.Message | list[data.Message] | None`
- update `generate_summariser_task(...)` to normalize single vs multiple messages
- keep `None` behavior unchanged
- add task coverage for the multi-message case
- clarify the summary and summariser documentation