### PR TITLE
fix(pipewire): handle richer EnumFormat parsing and channel limits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,15 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Cache and Install APT Libraries
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: |
-            libsndfile1
-            libasound2-dev
-            libffi-dev
-            portaudio19-dev
-          version: 1.1
+      - name: Install APT Libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsndfile1 libasound2-dev libffi-dev portaudio19-dev
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
             libasound2-dev
             libffi-dev
             portaudio19-dev
-          version: 1.0
+          version: 1.1
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,15 +46,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Cache and Install APT Libraries
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: |
-            libsndfile1
-            libasound2-dev
-            libffi-dev
-            portaudio19-dev
-          version: 1.0
+      - name: Install APT Libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsndfile1 libasound2-dev libffi-dev portaudio19-dev
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b

--- a/docs/tutorials/configuration.md
+++ b/docs/tutorials/configuration.md
@@ -112,8 +112,8 @@ The table below provides detailed information about the parameters available whe
 |---|---|---|---|---|
 | __Microphone__| | | Microphone configuration.| |
 | `microphone.device_name`| string | - | Will show the name of the connected usb microphone.| Ensure it matches the device in use.|
-| `microphone.samplerate`| int (Hz) | - | Sampling rate of the microphone in Hz. | Set the sampling rate according to the microphone's specifications.|
-|`microphone.audio_channels`| int | - | Number of audio channels (i.e., 1 for mono).| Configure according to the microphone's capabilities.|
+| `microphone.samplerate`| int (Hz) | - | Requested recording sample rate in Hz. | Use a rate appropriate for your microphone and recording workflow.|
+|`microphone.audio_channels`| int | - | Number of input audio channels to record. | Do not exceed the microphone's supported channel count.|
 | __Recording__| | | Microphone configuration.| |
 | `recording.duration`| int (sec.) | 3 | Duration in seconds for each audio recording. | Best kept at 3 seconds when using acoupi with ML classifiers models (e.g., batdetect2, birdnet) for optimal performance.|
 | `recording.interval`| int (sec.) | 10 | Interval in seconds between recordings. | Some pre-built programs with ML models (e.g., batdetect2) require processing time. This interval helps maintain good performance.|

--- a/src/acoupi/components/audio_recorder/pipewire_recorder.py
+++ b/src/acoupi/components/audio_recorder/pipewire_recorder.py
@@ -181,7 +181,12 @@ def _parse_pw_microphone_config(
     prompt: bool = True,
     prefix: str = "",
 ) -> PWRecorderConfig:
-    """Parse PipeWire recorder configuration from command-line arguments."""
+    """Parse PipeWire recorder configuration from command-line arguments.
+
+    When prompting, channel choices are constrained by the selected device's
+    advertised maximum input channels. Samplerate is treated as the requested
+    PipeWire recording rate.
+    """
     parser = ArgumentParser(description="Microphone configuration")
     parser.add_argument(
         f"--{prefix}device-name",
@@ -194,14 +199,14 @@ def _parse_pw_microphone_config(
         f"--{prefix}samplerate",
         dest="samplerate",
         type=int,
-        help="The samplerate of the microphone",
+        help="The requested recording samplerate",
         default=None,
     )
     parser.add_argument(
         f"--{prefix}audio-channels",
         dest="audio_channels",
         type=int,
-        help="The number of audio channels",
+        help="The requested number of input audio channels",
         default=None,
     )
 

--- a/src/acoupi/components/audio_recorder/pipewire_recorder.py
+++ b/src/acoupi/components/audio_recorder/pipewire_recorder.py
@@ -272,7 +272,10 @@ def _parse_pw_microphone_config(
 
         choice = click.prompt(
             "How many audio channels do you want to use?",
-            type=click.Choice([1, 2]),
+            type=click.IntRange(
+                min=1,
+                max=max(1, selected_device.max_input_channels),
+            ),
             default=1,
         )
         parsed.audio_channels = choice

--- a/src/acoupi/components/audio_recorder/pipewire_recorder.py
+++ b/src/acoupi/components/audio_recorder/pipewire_recorder.py
@@ -257,7 +257,7 @@ def _parse_pw_microphone_config(
 
         choice = click.prompt(
             "What samplerate do you want to use?",
-            type=click.Choice(rates),
+            type=click.IntRange(min=8_000, max=384_000),
             default=default,
         )
         parsed.samplerate = choice

--- a/src/acoupi/devices/audio/pipewire.py
+++ b/src/acoupi/devices/audio/pipewire.py
@@ -2,8 +2,9 @@
 
 import json
 from subprocess import CalledProcessError, run
+from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, TypeAdapter
 
 from acoupi.system.exceptions import DeviceUnavailableError
 
@@ -61,43 +62,128 @@ def get_input_devices() -> list[DeviceInfo]:
     ]
 
 
-def _extract_rate(rate_field) -> list[int]:
-    if isinstance(rate_field, int):
-        return [rate_field]
-    if isinstance(rate_field, list):
-        return [r for r in rate_field if isinstance(r, int)]
-    if isinstance(rate_field, dict):
-        default = rate_field.get("default")
-        min_rate = rate_field.get("min")
-        max_rate = rate_field.get("max")
-        rates = []
-        if isinstance(default, int):
-            rates.append(default)
-        if isinstance(min_rate, int) and isinstance(max_rate, int):
-            for r in [16000, 32000, 44100, 48000, 96000, 192000]:
-                if min_rate <= r <= max_rate:
-                    rates.append(r)
-        if not rates:
-            if isinstance(min_rate, int):
-                rates.append(min_rate)
-            if isinstance(max_rate, int):
-                rates.append(max_rate)
-        return rates
-    return [48000]
+class IntChoice(BaseModel):
+    default: int
+    min: int | None = None
+    max: int | None = None
+    step: int | None = None
+    model_config = ConfigDict(extra="allow")
+
+
+class FloatChoice(BaseModel):
+    default: float
+    min: float | None = None
+    max: float | None = None
+    step: float | None = None
+    model_config = ConfigDict(extra="allow")
+
+
+class StrChoice(BaseModel):
+    default: str
+    model_config = ConfigDict(extra="allow")
+
+
+class BoolChoice(BaseModel):
+    default: bool
+    model_config = ConfigDict(extra="allow")
+
+
+IntValue = int | IntChoice
+FloatValue = float | FloatChoice
+StrValue = str | StrChoice
+BoolValue = bool | BoolChoice
+
+
+class EnumFormatItem(BaseModel):
+    mediaType: Literal["audio"]
+    mediaSubtype: str
+
+    format: StrValue | None = None
+    rate: IntValue | None = None
+    channels: IntValue | None = None
+    position: list[str] | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+DEFAULT_SAMPLERATE = 48000
+DEFAULT_SAMPLERATE_CHOICES = [
+    16000,
+    32000,
+    44100,
+    48000,
+    96000,
+    192000,
+]
+
+
+def _extract_rate(rate_field: EnumFormatItem) -> list[int]:
+    rate_info = rate_field.rate
+
+    if isinstance(rate_info, int):
+        return [rate_info]
+
+    if rate_info is None:
+        return [DEFAULT_SAMPLERATE]
+
+    default = rate_info.default
+    min_rate = rate_info.min
+    max_rate = rate_info.max
+
+    rates = []
+    if isinstance(default, int):
+        rates.append(default)
+
+    if isinstance(min_rate, int):
+        rates.append(min_rate)
+
+    if isinstance(max_rate, int):
+        rates.append(max_rate)
+
+    if isinstance(min_rate, int) and isinstance(max_rate, int):
+        rates.extend(
+            r for r in DEFAULT_SAMPLERATE_CHOICES if min_rate <= r <= max_rate
+        )
+
+    return rates
+
+
+def _extract_channels(format_field: EnumFormatItem) -> int:
+    channels_info = format_field.channels
+
+    if isinstance(channels_info, int):
+        return channels_info
+
+    if channels_info is None:
+        return 1
+
+    default = channels_info.default
+    max_channels = channels_info.max
+
+    if isinstance(max_channels, int):
+        return max_channels
+
+    return default
 
 
 def _parse_pw_info(pw_info: dict) -> DeviceInfo:
     """Convert raw ``pw-dump`` node information into ``DeviceInfo``."""
     props = pw_info["props"]
-    formats = pw_info["params"]["EnumFormat"]
+    name = props["node.name"]
+    description = props.get("node.description", name)
+
+    adapter = TypeAdapter(list[EnumFormatItem])
+    formats = adapter.validate_python(pw_info["params"]["EnumFormat"])
+
     default_format = formats[0]
     samplerates = set()
     for f in formats:
-        samplerates.update(_extract_rate(f.get("rate", 48_000)))
+        samplerates.update(_extract_rate(f))
+
     return DeviceInfo(
-        name=props["node.name"],
-        description=props["node.description"],
-        max_input_channels=default_format["channels"],
+        name=name,
+        description=description,
+        max_input_channels=_extract_channels(default_format),
         samplerates=list(samplerates),
     )
 

--- a/src/acoupi/devices/audio/pipewire.py
+++ b/src/acoupi/devices/audio/pipewire.py
@@ -17,7 +17,7 @@ class DeviceInfo(BaseModel):
     """Normalized description of a PipeWire audio input device."""
 
     description: str
-    """The input index of the audio device."""
+    """Human-readable description of the audio device."""
 
     name: str
     """The name of the audio device."""
@@ -26,7 +26,7 @@ class DeviceInfo(BaseModel):
     """The maximum number of input channels."""
 
     samplerates: list[int]
-    """Listed supported sampling rates"""
+    """Advertised sampling-rate candidates derived from PipeWire formats."""
 
 
 def get_input_devices() -> list[DeviceInfo]:

--- a/src/acoupi/devices/audio/pipewire.py
+++ b/src/acoupi/devices/audio/pipewire.py
@@ -166,6 +166,10 @@ def _extract_channels(format_field: EnumFormatItem) -> int:
     return default
 
 
+def _extract_max_channels(formats: list[EnumFormatItem]) -> int:
+    return max(_extract_channels(format_field) for format_field in formats)
+
+
 def _parse_pw_info(pw_info: dict) -> DeviceInfo:
     """Convert raw ``pw-dump`` node information into ``DeviceInfo``."""
     props = pw_info["props"]
@@ -175,7 +179,6 @@ def _parse_pw_info(pw_info: dict) -> DeviceInfo:
     adapter = TypeAdapter(list[EnumFormatItem])
     formats = adapter.validate_python(pw_info["params"]["EnumFormat"])
 
-    default_format = formats[0]
     samplerates = set()
     for f in formats:
         samplerates.update(_extract_rate(f))
@@ -183,7 +186,7 @@ def _parse_pw_info(pw_info: dict) -> DeviceInfo:
     return DeviceInfo(
         name=name,
         description=description,
-        max_input_channels=_extract_channels(default_format),
+        max_input_channels=_extract_max_channels(formats),
         samplerates=list(samplerates),
     )
 

--- a/tests/test_components/test_audio_recording/test_pipewire_recorder.py
+++ b/tests/test_components/test_audio_recording/test_pipewire_recorder.py
@@ -399,3 +399,52 @@ class TestParsePWRecorderConfig:
                 ],
                 prompt=False,
             )
+
+    def test_prompts_for_channels_up_to_selected_device_maximum(
+        self, monkeypatch
+    ):
+        device = DeviceInfo(
+            name="alsa_input.usb-Surround_Device-00.analog-surround-51",
+            description="Surround Device",
+            max_input_channels=6,
+            samplerates=[48000, 96000],
+        )
+        prompts = []
+
+        monkeypatch.setattr(
+            "acoupi.components.audio_recorder.pipewire_recorder.get_input_devices",
+            lambda: [device],
+        )
+
+        def fake_prompt(text, **kwargs):
+            prompts.append((text, kwargs))
+
+            if text == "What samplerate do you want to use?":
+                return 48000
+
+            if text == "How many audio channels do you want to use?":
+                prompt_type = kwargs["type"]
+                assert prompt_type.min == 1
+                assert prompt_type.max == 6
+                return 6
+
+            raise AssertionError(f"Unexpected prompt: {text}")
+
+        monkeypatch.setattr(
+            "acoupi.components.audio_recorder.pipewire_recorder.click.prompt",
+            fake_prompt,
+        )
+
+        config = _parse_pw_microphone_config(
+            [
+                "--device-name=alsa_input.usb-Surround_Device-00.analog-surround-51"
+            ],
+            prompt=True,
+        )
+
+        assert config.samplerate == 48000
+        assert config.audio_channels == 6
+        assert [text for text, _ in prompts] == [
+            "What samplerate do you want to use?",
+            "How many audio channels do you want to use?",
+        ]

--- a/tests/test_devices/test_audio/test_pipewire.py
+++ b/tests/test_devices/test_audio/test_pipewire.py
@@ -82,6 +82,63 @@ class TestGetInputDevices:
         ):
             get_input_devices()
 
+    def test_parses_enumformat_choice_objects_and_aggregates_channels(
+        self, monkeypatch, make_completed_process
+    ):
+        payload = [
+            {
+                "id": 60,
+                "type": "PipeWire:Interface:Node",
+                "info": {
+                    "props": {
+                        "media.class": "Audio/Source",
+                        "node.name": "alsa_input.usb-test_device.analog-surround-51",
+                        "node.description": "Test Device",
+                    },
+                    "params": {
+                        "EnumFormat": [
+                            {
+                                "mediaType": "audio",
+                                "mediaSubtype": "raw",
+                                "rate": {
+                                    "default": 48000,
+                                    "min": 44100,
+                                    "max": 96000,
+                                },
+                                "channels": {
+                                    "default": 1,
+                                    "min": 1,
+                                    "max": 1,
+                                },
+                            },
+                            {
+                                "mediaType": "audio",
+                                "mediaSubtype": "raw",
+                                "rate": 192000,
+                                "channels": {
+                                    "default": 6,
+                                    "min": 2,
+                                    "max": 6,
+                                },
+                            },
+                        ]
+                    },
+                },
+            }
+        ]
+        monkeypatch.setattr(
+            "acoupi.devices.audio.pipewire.run",
+            lambda *args, **kwargs: make_completed_process(
+                json.dumps(payload)
+            ),
+        )
+
+        devices = get_input_devices()
+
+        assert len(devices) == 1
+        assert devices[0].max_input_channels == 6
+        assert sorted(devices[0].samplerates) == [44100, 48000, 96000, 192000]
+
 
 class TestGetInputDeviceByName:
     def test_returns_matching_device(


### PR DESCRIPTION
## Summary

This PR rounds out the recent PipeWire `pw-dump` parsing work.

It was prompted by testing with AudioMoth USB recorders, which advertised supported sample rates through a range-style `EnumFormat` object. Our previous parsing did not handle that shape correctly, so device capability discovery could fail.

This PR keeps the new `EnumFormat` parsing model, fixes channel capability extraction, and updates the interactive recorder prompt to respect the selected device's advertised channel limit.

## Changes

- improve PipeWire `EnumFormat` handling with targeted test coverage
- derive `max_input_channels` from all advertised formats instead of only the first one
- allow the PipeWire recorder prompt to request channels up to the selected device maximum
- clarify PipeWire recorder/configuration docstrings and user docs around samplerate and channel behavior

## Why

Testing with AudioMoth USB recorders exposed that some PipeWire devices advertise samplerates as a range object rather than a single integer value. That caused our previous `pw-dump` parsing to fail for those devices.

Also, some PipeWire devices advertise multiple formats with different channel counts. Previously we only used the first format, which could underreport the device's actual input capability.

The recorder prompt also still assumed a hard-coded 1 or 2 channel selection, which no longer matched the richer device parsing.