### PR TITLE
Avoid GUANO backup files when writing recording metadata

### DIFF
--- a/src/acoupi/tasks/recording.py
+++ b/src/acoupi/tasks/recording.py
@@ -132,4 +132,4 @@ def add_guano_metadata(recording: data.Recording) -> None:
             recording.deployment.longitude,
         )
 
-    g.write()
+    g.write(make_backup=False)


### PR DESCRIPTION
## Summary

Prevent GUANO metadata writes from creating backup files alongside recordings by passing `make_backup=False` when saving metadata.