### PR TITLE
Allow detection builders to return multiple messages

### DIFF
--- a/docs/explanation/tasks.md
+++ b/docs/explanation/tasks.md
@@ -63,7 +63,7 @@ The recording task builds upon the acoupi components: `AudioRecorder` to capture
 #### Detection
 
 The [Detection](../reference/tasks.md) task is responsible for processing audio files.
-The task builds upon the acoupi components: `ProcessingFilter` to determine if a recording should be processed, `Model` to run an audio classifier model, `ModelOutputCleaner` to cleans the model outputs, `MessageBuilder` to generate messages with the detected information, and `Store` and `MessageStore` to save the metadata of the procesed recordings and store the messages to be sent.
+The task builds upon the acoupi components: `ProcessingFilter` to determine if a recording should be processed, `Model` to run an audio classifier model, `ModelOutputCleaner` to cleans the model outputs, `MessageBuilder` to generate no message, one message, or multiple messages with the detected information, and `Store` and `MessageStore` to save the metadata of the procesed recordings and store the messages to be sent.
 
 <figure markdown="span">
     ![Figure 2: Overview of the detection task](../img/task_02_model.png){ width="110%" }

--- a/src/acoupi/components/message_factories.py
+++ b/src/acoupi/components/message_factories.py
@@ -10,8 +10,9 @@ when connectivity is limited. For example, message factories
 can be used to filter detections with low score.
 
 Message factories are implemented as classes that inherit from MessageBuilder. The class should
-implement the build_message method, which takes a model output and returns a message. Built-in
-message factories emit JSON text, but custom factories may emit raw bytes for binary transports.
+implement the build_message method, which takes a model output and returns no message, one message,
+or multiple messages. Built-in message factories emit JSON text, but custom factories may emit raw
+bytes for binary transports.
 """
 
 from typing import List, Optional, Sequence

--- a/src/acoupi/components/types.py
+++ b/src/acoupi/components/types.py
@@ -434,13 +434,13 @@ class MessageBuilder(ABC, Generic[P]):
         self,
         *args: P.args,
         **kwargs: P.kwargs,
-    ) -> Optional[data.Message]:
+    ) -> None | data.Message | list[data.Message]:
         """Will build a message or return None depending on the input data.
 
         Returns
         -------
-        Optional[data.Message]
-            The assembled message or None if the input data is not suitable.
+        data.Message | list[data.Message] | None
+            One message, multiple messages, or None if there is nothing to send.
 
         """
 

--- a/src/acoupi/tasks/detection.py
+++ b/src/acoupi/tasks/detection.py
@@ -73,14 +73,14 @@ def generate_detection_task(
         - Store the cleaned outputs of the model in the store.
         - See [components.stores][acoupi.components.stores] for implementation
         of [types.Store][acoupi.components.types.Store].
-    5. **message_factory.build_message(model_output)** -> data.Message
-        - Create messages to be sent using the Messenger.
+    5. **message_factory.build_message(model_output)** -> data.Message | list[data.Message] | None
+        - Create one or more messages to be sent using the Messenger.
         - See
         [components.message_factories][acoupi.components.message_factories] for
         implementations of
         [types.MessageBuilder][acoupi.components.types.MessageBuilder].
     6. **message_store.store_message(message)** -> None
-        - Store the message in the message store.
+        - Store each message in the message store.
         - See [components.message_stores][acoupi.components.message_stores] for
         implementation of [types.Store][acoupi.components.types.Store].
     """
@@ -112,9 +112,15 @@ def generate_detection_task(
 
         # Create messages
         for message_factory in message_factories or []:
-            message = message_factory.build_message(model_output)
+            messages = message_factory.build_message(model_output)
 
-            if message is not None:
+            if messages is None:
+                continue
+
+            if not isinstance(messages, list):
+                messages = [messages]
+
+            for message in messages:
                 logger.info("Storing message.")
                 message_store.store_message(message)
 

--- a/tests/test_tasks/test_detection_task.py
+++ b/tests/test_tasks/test_detection_task.py
@@ -1,0 +1,91 @@
+"""Test suite for the detection task generator."""
+
+from unittest.mock import call
+
+from acoupi import data
+from acoupi.tasks import generate_detection_task
+
+
+def test_detection_task_stores_all_messages_from_builder(
+    recording,
+    model_output,
+    mocker,
+):
+    """Test that detection tasks store every message returned by a builder."""
+    model = mocker.Mock()
+    model.run.return_value = model_output
+    store = mocker.Mock()
+    message_store = mocker.Mock()
+    messages = [
+        data.Message(content="first"),
+        data.Message(content="second"),
+    ]
+    message_factory = mocker.Mock()
+    message_factory.build_message.return_value = messages
+
+    task = generate_detection_task(
+        store=store,
+        model=model,
+        message_store=message_store,
+        message_factories=[message_factory],
+    )
+
+    task(recording)
+
+    message_factory.build_message.assert_called_once_with(model_output)
+    assert message_store.store_message.call_args_list == [
+        call(messages[0]),
+        call(messages[1]),
+    ]
+
+
+def test_detection_task_still_stores_single_message(
+    recording,
+    model_output,
+    mocker,
+):
+    """Test that existing single-message builder behaviour is preserved."""
+    model = mocker.Mock()
+    model.run.return_value = model_output
+    store = mocker.Mock()
+    message_store = mocker.Mock()
+    message = data.Message(content="single")
+    message_factory = mocker.Mock()
+    message_factory.build_message.return_value = message
+
+    task = generate_detection_task(
+        store=store,
+        model=model,
+        message_store=message_store,
+        message_factories=[message_factory],
+    )
+
+    task(recording)
+
+    message_store.store_message.assert_called_once_with(message)
+
+
+def test_detection_task_skips_none_message_from_builder(
+    recording,
+    model_output,
+    mocker,
+):
+    """Test that builders can still opt out by returning None."""
+    model = mocker.Mock()
+    model.run.return_value = model_output
+    store = mocker.Mock()
+    message_store = mocker.Mock()
+    message_factory = mocker.Mock()
+    message_factory.build_message.return_value = None
+
+    task = generate_detection_task(
+        store=store,
+        model=model,
+        message_store=message_store,
+        message_factories=[message_factory],
+    )
+
+    task(recording)
+
+    message_factory.build_message.assert_called_once_with(model_output)
+    message_store.store_message.assert_not_called()


### PR DESCRIPTION
## Summary

Adds support for detection message builders to return multiple messages.

Detection tasks now handle builders that return:

- `None`, when there is nothing to send
- a single `Message`
- a list of `Message` objects

The task stores each returned message individually, while preserving the previous single-message behavior.

## Changes

- Updated detection task message handling to support multiple messages.
- Updated `MessageBuilder` return type and related docs.
- Added tests for multiple messages, single-message behavior, and `None`.

## Testing

- `uv run pytest tests/test_tasks/test_detection_task.py`
- `uv run ruff check src/acoupi/components/types.py src/acoupi/tasks/detection.py src/acoupi/components/message_factories.py tests/test_tasks/test_detection_task.py`