### PR TITLE
fix(pipewire): skip devices without advertised formats

### DIFF
--- a/src/acoupi/devices/audio/pipewire.py
+++ b/src/acoupi/devices/audio/pipewire.py
@@ -59,6 +59,7 @@ def get_input_devices() -> list[DeviceInfo]:
         if device.get("type") == "PipeWire:Interface:Node"
         and (info := device.get("info")) is not None
         and info.get("props", {}).get("media.class") == "Audio/Source"
+        and info.get("params", {}).get("EnumFormat")
     ]
 
 

--- a/src/acoupi/system/config/parsers.py
+++ b/src/acoupi/system/config/parsers.py
@@ -460,6 +460,7 @@ def get_field_dtype(field: FieldInfo) -> type:
     # Check for optional fields and remove the
     # typing.Optional if present
     import types
+
     if origin in (Union, getattr(types, "UnionType", None)):
         nested = get_args(annotation)[0]
         return nested

--- a/tests/test_devices/test_audio/test_pipewire.py
+++ b/tests/test_devices/test_audio/test_pipewire.py
@@ -139,6 +139,35 @@ class TestGetInputDevices:
         assert devices[0].max_input_channels == 6
         assert sorted(devices[0].samplerates) == [44100, 48000, 96000, 192000]
 
+    def test_defaults_channels_when_no_formats_are_listed(
+        self, monkeypatch, make_completed_process
+    ):
+        payload = [
+            {
+                "id": 60,
+                "type": "PipeWire:Interface:Node",
+                "info": {
+                    "props": {
+                        "media.class": "Audio/Source",
+                        "node.name": "alsa_input.empty-formats",
+                        "node.description": "Empty Formats Device",
+                    },
+                    "params": {"EnumFormat": []},
+                },
+            }
+        ]
+        monkeypatch.setattr(
+            "acoupi.devices.audio.pipewire.run",
+            lambda *args, **kwargs: make_completed_process(
+                json.dumps(payload)
+            ),
+        )
+
+        devices = get_input_devices()
+
+        assert len(devices) == 1
+        assert devices[0].max_input_channels == 1
+
 
 class TestGetInputDeviceByName:
     def test_returns_matching_device(

--- a/tests/test_devices/test_audio/test_pipewire.py
+++ b/tests/test_devices/test_audio/test_pipewire.py
@@ -139,7 +139,7 @@ class TestGetInputDevices:
         assert devices[0].max_input_channels == 6
         assert sorted(devices[0].samplerates) == [44100, 48000, 96000, 192000]
 
-    def test_defaults_channels_when_no_formats_are_listed(
+    def test_skips_devices_when_no_formats_are_listed(
         self, monkeypatch, make_completed_process
     ):
         payload = [
@@ -163,10 +163,7 @@ class TestGetInputDevices:
             ),
         )
 
-        devices = get_input_devices()
-
-        assert len(devices) == 1
-        assert devices[0].max_input_channels == 1
+        assert get_input_devices() == []
 
 
 class TestGetInputDeviceByName:


### PR DESCRIPTION
## Summary

- Skip PipeWire audio source nodes that do not advertise any `EnumFormat` entries.
- Prevent `get_input_devices()` from computing max channels from an empty format list.
- Add regression coverage for PipeWire source devices with empty `EnumFormat`.
- Include Ruff formatting cleanup from the verification run.

## Testing

- `make fix`
- `make format`
- `make lint`
- `make test`

Result: `358 passed, 1 skipped`